### PR TITLE
C2PA-626: Override toolchain channel in the directory for the cargo-edit install during GH workflow

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -32,6 +32,8 @@
     "reqs",
     "sfnt",
     "Stubber",
+    "toolset",
+    "rustup",
     "thiserror",
     "xdadau"
   ]

--- a/.github/actions/create-version-update-prs/action.yml
+++ b/.github/actions/create-version-update-prs/action.yml
@@ -37,11 +37,18 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # Override the local toolset to the latest stable version, as the cargo-edit uses 
+    # a lock file that is `version 4`.
+    - name: Set to latest toolset
+      shell: bash
+      run: rustup override set stable
+
     # Install cargo-edit so we can update workspace version
     - name: Install cargo-edit
       uses: baptiste0928/cargo-install@v3
       with:
         crate: cargo-edit
+        args: --ignore-rust-version
 
     # Update workspace version using cargo-edit
     - name: Update workspace version

--- a/.github/actions/create-version-update-prs/action.yml
+++ b/.github/actions/create-version-update-prs/action.yml
@@ -48,7 +48,6 @@ runs:
       uses: baptiste0928/cargo-install@v3
       with:
         crate: cargo-edit
-        args: --ignore-rust-version
 
     # Update workspace version using cargo-edit
     - name: Update workspace version


### PR DESCRIPTION
<!--  Title should use the format: "ISSUE-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/ISSUE-123/featureName"  -->
<!--        Branch names for Bugs: "fix/ISSUE-123/bugFixName"       -->
# Issue(s)

- C2PA-626

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [ ] **Merge Commit** will be updated with `(MAJOR)` | `(MINOR)` when appropriate
- [ ] **PR labeled** appropriately
- [ ] Changes include a single fix/feature
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [ ] **Test case(s)** added
  - [ ] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

Was running into an issue where the cargo.lock file for cargo-edit was not parseable with 1.75 toolchain, as it was using `version 4`. This change overrides the local toolchain to stable during the action.

# Verification Instructions
<!-- Instructions for checking or testing this change. -->