### PR TITLE
C2PA-628: (MINOR) Fix the checksum calculation of the SFNT C2PA table

### DIFF
--- a/c2pa-font-handler/src/c2pa.rs
+++ b/c2pa-font-handler/src/c2pa.rs
@@ -17,13 +17,11 @@
 use crate::{error::FontIoError, sfnt::table::TableC2PA};
 
 /// Default major version
-pub(crate) const DEFAULT_MAJOR_VERSION: u16 = 1u16;
-/// Minimum major version
-pub(crate) const MIN_MAJOR_VERSION: u16 = 1u16;
+pub(crate) const DEFAULT_MAJOR_VERSION: u16 = 0u16;
 /// Maximum major version
-pub(crate) const MAX_MAJOR_VERSION: u16 = 1u16;
+pub(crate) const MAX_MAJOR_VERSION: u16 = 0u16;
 /// Default minor version
-pub(crate) const DEFAULT_MINOR_VERSION: u16 = 4u16;
+pub(crate) const DEFAULT_MINOR_VERSION: u16 = 1u16;
 
 /// Support for adding/removing [`ContentCredentialRecord`] items.
 pub trait C2PASupport {
@@ -220,9 +218,7 @@ impl ContentCredentialRecordBuilder {
     ) -> Result<ContentCredentialRecord, crate::error::FontIoError> {
         // Grab the major version
         let major_version = self.major_version.unwrap_or(DEFAULT_MAJOR_VERSION);
-        if major_version < MIN_MAJOR_VERSION
-            || major_version > MAX_MAJOR_VERSION
-        {
+        if major_version > MAX_MAJOR_VERSION {
             return Err(crate::error::FontIoError::InvalidC2paMajorVersion(
                 major_version,
             ));

--- a/c2pa-font-handler/src/c2pa.rs
+++ b/c2pa-font-handler/src/c2pa.rs
@@ -225,8 +225,8 @@ impl ContentCredentialRecordBuilder {
         }
         // And grab the minor version
         let minor_version = self.minor_version.unwrap_or(DEFAULT_MINOR_VERSION);
-        // Which we can check for a v1, to make sure it is only a minor of 4
-        if major_version == 1u16 && minor_version != 4u16 {
+        // For now we only support 0.1
+        if major_version == 0u16 && minor_version != 1u16 {
             return Err(crate::error::FontIoError::InvalidC2paMinorVersion(
                 minor_version,
             ));

--- a/c2pa-font-handler/src/c2pa_test.rs
+++ b/c2pa-font-handler/src/c2pa_test.rs
@@ -87,6 +87,18 @@ fn test_record_builder_invalid_minor_version() {
 }
 
 #[test]
+fn test_record_builder_invalid_minor_version_with_valid_major() {
+    let result = ContentCredentialRecord::builder()
+        .with_version(0, 0)
+        .with_active_manifest_uri("http://example.com/manifest".to_owned())
+        .with_content_credential(vec![1, 2, 3, 4])
+        .build();
+    assert!(result.is_err());
+    let error = result.err().unwrap();
+    assert!(matches!(error, FontIoError::InvalidC2paMinorVersion(0)));
+}
+
+#[test]
 fn test_update_record_removed_items() {
     let update_record = UpdateContentCredentialRecord::builder()
         .without_active_manifest_uri()

--- a/c2pa-font-handler/src/c2pa_test.rs
+++ b/c2pa-font-handler/src/c2pa_test.rs
@@ -19,8 +19,8 @@ use super::*;
 #[test]
 fn test_record_getters() {
     let record = ContentCredentialRecord::default();
-    assert_eq!(record.major_version(), 1);
-    assert_eq!(record.minor_version(), 4);
+    assert_eq!(record.major_version(), 0);
+    assert_eq!(record.minor_version(), 1);
     assert_eq!(record.active_manifest_uri(), None,);
     assert!(record.content_credential().is_none());
 }
@@ -28,7 +28,7 @@ fn test_record_getters() {
 #[test]
 fn test_record_builder() {
     let result = ContentCredentialRecord::builder()
-        .with_version(1, 4)
+        .with_version(0, 1)
         .with_active_manifest_uri("http://example.com/manifest".to_owned())
         .with_content_credential(vec![1, 2, 3, 4])
         .build();
@@ -36,8 +36,8 @@ fn test_record_builder() {
     assert!(result.is_ok());
     let record = result.unwrap();
     if let ContentCredentialRecord {
-        major_version: 1,
-        minor_version: 4,
+        major_version: 0,
+        minor_version: 1,
         active_manifest_uri: Some(uri),
         content_credential: Some(credential),
     } = record
@@ -55,8 +55,8 @@ fn test_record_builder_default() {
     assert!(result.is_ok());
     let record = result.unwrap();
     if let ContentCredentialRecord {
-        major_version: 1,
-        minor_version: 4,
+        major_version: 0,
+        minor_version: 1,
         active_manifest_uri: None,
         content_credential: None,
     } = record

--- a/c2pa-font-handler/src/sfnt/font_test.rs
+++ b/c2pa-font-handler/src/sfnt/font_test.rs
@@ -153,7 +153,7 @@ fn test_write_font_with_c2pa() {
     let mut reader = std::io::Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let record = ContentCredentialRecord::builder()
-        .with_version(1, 4)
+        .with_version(0, 1)
         .with_active_manifest_uri("https://example.com".to_string())
         .with_content_credential(vec![0x00, 0x01, 0x02, 0x03])
         .build()
@@ -229,7 +229,7 @@ fn test_adding_c2pa_record() {
     let mut reader = std::io::Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let record = ContentCredentialRecord::builder()
-        .with_version(1, 4)
+        .with_version(0, 1)
         .with_active_manifest_uri("https://example.com".to_string())
         .with_content_credential(vec![0x00, 0x01, 0x02, 0x03])
         .build()
@@ -240,8 +240,8 @@ fn test_adding_c2pa_record() {
     let result = font.get_c2pa();
     assert!(result.is_ok());
     let record = result.unwrap().unwrap();
-    assert_eq!(record.major_version(), 1);
-    assert_eq!(record.minor_version(), 4);
+    assert_eq!(record.major_version(), 0);
+    assert_eq!(record.minor_version(), 1);
     assert_eq!(record.active_manifest_uri().unwrap(), "https://example.com");
     assert_eq!(
         record.content_credential().unwrap(),
@@ -255,7 +255,7 @@ fn test_adding_c2pa_record_when_one_exists() {
     let mut reader = std::io::Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let record = ContentCredentialRecord::builder()
-        .with_version(1, 4)
+        .with_version(0, 1)
         .with_active_manifest_uri("https://example.com".to_string())
         .with_content_credential(vec![0x00, 0x01, 0x02, 0x03])
         .build()
@@ -275,7 +275,7 @@ fn test_removing_c2pa_record() {
     let mut reader = std::io::Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let record = ContentCredentialRecord::builder()
-        .with_version(1, 4)
+        .with_version(0, 1)
         .with_active_manifest_uri("https://example.com".to_string())
         .with_content_credential(vec![0x00, 0x01, 0x02, 0x03])
         .build()
@@ -308,7 +308,7 @@ fn test_updating_c2pa_record_when_occupied() {
     let mut reader = std::io::Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let record = ContentCredentialRecord::builder()
-        .with_version(1, 4)
+        .with_version(0, 1)
         .with_active_manifest_uri("https://example.com".to_string())
         .with_content_credential(vec![0x00, 0x01, 0x02, 0x03])
         .build()
@@ -323,8 +323,8 @@ fn test_updating_c2pa_record_when_occupied() {
     let result = font.get_c2pa();
     assert!(result.is_ok());
     let record = result.unwrap().unwrap();
-    assert_eq!(record.major_version(), 1);
-    assert_eq!(record.minor_version(), 4);
+    assert_eq!(record.major_version(), 0);
+    assert_eq!(record.minor_version(), 1);
     assert_eq!(record.active_manifest_uri(), None);
     assert_eq!(
         record.content_credential().unwrap(),
@@ -345,8 +345,8 @@ fn test_updating_c2pa_record_when_vacant() {
     let result = font.get_c2pa();
     assert!(result.is_ok());
     let record = result.unwrap().unwrap();
-    assert_eq!(record.major_version(), 1);
-    assert_eq!(record.minor_version(), 4);
+    assert_eq!(record.major_version(), 0);
+    assert_eq!(record.minor_version(), 1);
     assert_eq!(record.active_manifest_uri(), None);
     assert_eq!(record.content_credential(), None);
 }

--- a/c2pa-font-handler/src/sfnt/table/c2pa.rs
+++ b/c2pa-font-handler/src/sfnt/table/c2pa.rs
@@ -262,7 +262,10 @@ impl FontDataChecksum for TableC2PA {
             Wrapping(0)
         };
         let store_cksum = if let Some(store) = &self.manifest_store {
-            utils::checksum(store)
+            utils::checksum_biased(
+                store,
+                raw_table.activeManifestUriLength as u32,
+            )
         } else {
             Wrapping(0)
         };

--- a/c2pa-font-handler/src/sfnt/table/named_table_test.rs
+++ b/c2pa-font-handler/src/sfnt/table/named_table_test.rs
@@ -47,10 +47,7 @@ fn test_named_table_c2pa_len() {
 fn test_named_table_c2pa_checksum() {
     let c2pa = NamedTable::C2PA(TableC2PA::default());
     let checksum = c2pa.checksum();
-    let mut expected_checksum = Wrapping(0x00000000);
-    // Make 32-bit big-endian checksum
-    // Shift the major version by 16 bits to the left and add the minor version
-    expected_checksum += Wrapping(65536 + 4);
+    let expected_checksum = Wrapping(0x00000001);
     assert_eq!(checksum, expected_checksum);
 }
 
@@ -62,8 +59,8 @@ fn test_named_table_c2pa_write() {
     assert_eq!(
         writer.into_inner(),
         vec![
-            0x00, 0x01, // major_version
-            0x00, 0x04, // minor_version
+            0x00, 0x00, // major_version
+            0x00, 0x01, // minor_version
             0x00, 0x00, 0x00, 0x00, // active manifest uri offset
             0x00, 0x00, // active manifest uri length
             0x00, 0x00, // reserved

--- a/c2pa-font-handler/src/utils.rs
+++ b/c2pa-font-handler/src/utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Monotype Imaging Inc.
+// Copyright 2024-2025 Monotype Imaging Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/c2pa-font-handler/src/utils_test.rs
+++ b/c2pa-font-handler/src/utils_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Monotype Imaging Inc.
+// Copyright 2024-2025 Monotype Imaging Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/c2pa-font-handler/src/utils_test.rs
+++ b/c2pa-font-handler/src/utils_test.rs
@@ -36,3 +36,106 @@ fn test_checksum() {
     let checksum = checksum(&data);
     assert_eq!(checksum, Wrapping(0x00010203));
 }
+
+/// Verifies the adding of a remote C2PA manifest reference works as
+/// expected.
+#[test]
+fn test_checksum_and_biased() {
+    let data = [
+        0x0f, 0x0f, 0x0f, 0x0f, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x01, 0x01, 0x00,
+    ];
+    let expected: [[u32; 17]; 4] = [
+        [
+            0x00000000_u32,
+            0x0f000000_u32,
+            0x0f0f0000_u32,
+            0x0f0f0f00_u32,
+            0x0f0f0f0f_u32,
+            0x130f0f0f_u32,
+            0x13120f0f_u32,
+            0x1312110f_u32,
+            0x13121110_u32,
+            0x13121110_u32,
+            0x13121110_u32,
+            0x13121110_u32,
+            0x13121110_u32,
+            0x13121110_u32,
+            0x13131110_u32,
+            0x13131210_u32,
+            0x13131210_u32,
+        ],
+        [
+            0x00000000_u32,
+            0x000f0000_u32,
+            0x000f0f00_u32,
+            0x000f0f0f_u32,
+            0x0f0f0f0f_u32,
+            0x0f130f0f_u32,
+            0x0f13120f_u32,
+            0x0f131211_u32,
+            0x10131211_u32,
+            0x10131211_u32,
+            0x10131211_u32,
+            0x10131211_u32,
+            0x10131211_u32,
+            0x10131211_u32,
+            0x10131311_u32,
+            0x10131312_u32,
+            0x10131312_u32,
+        ],
+        [
+            0x00000000_u32,
+            0x00000f00_u32,
+            0x00000f0f_u32,
+            0x0f000f0f_u32,
+            0x0f0f0f0f_u32,
+            0x0f0f130f_u32,
+            0x0f0f1312_u32,
+            0x110f1312_u32,
+            0x11101312_u32,
+            0x11101312_u32,
+            0x11101312_u32,
+            0x11101312_u32,
+            0x11101312_u32,
+            0x11101312_u32,
+            0x11101313_u32,
+            0x12101313_u32,
+            0x12101313_u32,
+        ],
+        [
+            0x00000000_u32,
+            0x0000000f_u32,
+            0x0f00000f_u32,
+            0x0f0f000f_u32,
+            0x0f0f0f0f_u32,
+            0x0f0f0f13_u32,
+            0x120f0f13_u32,
+            0x12110f13_u32,
+            0x12111013_u32,
+            0x12111013_u32,
+            0x12111013_u32,
+            0x12111013_u32,
+            0x12111013_u32,
+            0x12111013_u32,
+            0x13111013_u32,
+            0x13121013_u32,
+            0x13121013_u32,
+        ],
+    ];
+    for frag_length in 0..data.len() {
+        // Create a fragment from the first N bytes
+        let frag_0n = &data[0..frag_length];
+        // Verify its checksum for different bias values
+        let cksum = checksum(frag_0n);
+        let cksum_0 = checksum_biased(frag_0n, 0);
+        let cksum_1 = checksum_biased(frag_0n, 1);
+        let cksum_2 = checksum_biased(frag_0n, 2);
+        let cksum_3 = checksum_biased(frag_0n, 3);
+        assert_eq!(expected[0][frag_length], cksum.0);
+        assert_eq!(expected[0][frag_length], cksum_0.0);
+        assert_eq!(expected[1][frag_length], cksum_1.0);
+        assert_eq!(expected[2][frag_length], cksum_2.0);
+        assert_eq!(expected[3][frag_length], cksum_3.0);
+    }
+}


### PR DESCRIPTION
<!--  Title should use the format: "ISSUE-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/ISSUE-123/featureName"  -->
<!--        Branch names for Bugs: "fix/ISSUE-123/bugFixName"       -->
# Issue(s)

- C2PA-628 

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [X] **Merge Commit** will be updated with `(MAJOR)` | `(MINOR)` when appropriate
- [X] **PR labeled** appropriately
- [X] Changes include a single fix/feature
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [X] **Test case(s)** added
  - [X] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

Previously we were not correctly calculating the checksum of the `C2PA` table when the active manifest uri was not a 4-byte aligned value. I added a new unit test that uses `"test1"`, which contains 5 bytes instead of the _lucky_ 4 of `"test"`. I also kept the older unit test with just `"test"` to show it works when 4-byte aligned and when it is not 4-byte aligned.

We also incorrectly set the version of the C2PA table to 1.4, changed to 0.1.

# Verification Instructions
<!-- Instructions for checking or testing this change. -->