### PR TITLE
C2PA-629: (MINOR) Adds the ability to read chunks and get their positions for fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
@@ -638,6 +639,27 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = { version = "2.0.6" }
 tokio = { version = "1.42.0", features = ["full"] }
 tracing = { version = "0.1.41" }
 tracing-subscriber = { version = "0.3.19", features = ["json", "env-filter"] }
+tracing-test = { version = "0.2.5" }
 
 [workspace.lints.rust]
 missing_docs = "deny"

--- a/c2pa-font-handler/Cargo.toml
+++ b/c2pa-font-handler/Cargo.toml
@@ -40,6 +40,7 @@ tracing.workspace = true
 clap.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
+tracing-test.workspace = true
 
 [lints]
 workspace = true

--- a/c2pa-font-handler/src/chunks.rs
+++ b/c2pa-font-handler/src/chunks.rs
@@ -1,0 +1,131 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Definitions of chunks for various font softwares
+
+use std::io::{Read, Seek};
+
+/// A trait for reading data chunks.
+pub trait ChunkReader {
+    /// The error type for reading data chunks.
+    type Error;
+
+    /// Get the positions of all chunks in the data.
+    fn get_chunk_positions(
+        reader: &mut (impl Read + Seek + ?Sized),
+    ) -> Result<Vec<ChunkPosition>, Self::Error>;
+}
+
+/// A chunk type
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ChunkType {
+    /// Header
+    Header,
+    /// Directory entry
+    DirectoryEntry,
+    /// Table data
+    TableData,
+}
+
+impl std::fmt::Display for ChunkType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ChunkType::Header => write!(f, "Header"),
+            ChunkType::DirectoryEntry => write!(f, "Directory Entry"),
+            ChunkType::TableData => write!(f, "Table Data"),
+        }
+    }
+}
+
+/// A chunk position
+#[derive(Debug, Eq, PartialEq)]
+pub struct ChunkPosition {
+    /// Offset to the start of the chunk
+    offset: usize,
+    /// Length of the chunk
+    length: usize,
+    /// Name, or tag, of the chunk
+    name: [u8; 4],
+    /// Type of chunk
+    chunk_type: ChunkType,
+    /// Whether the chunk should be hashed
+    should_hash: bool,
+}
+
+impl ChunkPosition {
+    /// Create a new chunk position
+    pub fn new(
+        offset: usize,
+        length: usize,
+        name: [u8; 4],
+        chunk_type: ChunkType,
+        should_hash: bool,
+    ) -> Self {
+        Self {
+            offset,
+            length,
+            name,
+            chunk_type,
+            should_hash,
+        }
+    }
+
+    /// Get the name as a string
+    pub fn name_as_string(&self) -> Result<String, std::string::FromUtf8Error> {
+        String::from_utf8(self.name.to_vec())
+    }
+
+    /// Get the offset of the chunk
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Get the length of the chunk data
+    pub fn length(&self) -> usize {
+        self.length
+    }
+
+    /// Get the name of the chunk
+    pub fn name(&self) -> &[u8; 4] {
+        &self.name
+    }
+
+    /// Get the type of the chunk
+    pub fn chunk_type(&self) -> &ChunkType {
+        &self.chunk_type
+    }
+
+    /// Should the chunk be hashed
+    pub fn should_hash(&self) -> bool {
+        self.should_hash
+    }
+}
+
+impl std::fmt::Display for ChunkPosition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Chunk({}): {} at offset {} with length {}; hash: {}",
+            self.chunk_type,
+            String::from_utf8_lossy(&self.name),
+            self.offset,
+            self.length,
+            self.should_hash,
+        )
+    }
+}
+
+#[cfg(test)]
+#[path = "chunks_test.rs"]
+mod tests;

--- a/c2pa-font-handler/src/chunks_test.rs
+++ b/c2pa-font-handler/src/chunks_test.rs
@@ -1,0 +1,54 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Tests for the chunk reader types
+
+use super::*;
+
+#[test]
+fn test_chunk_position() {
+    let chunk = ChunkPosition::new(0, 4, *b"head", ChunkType::Header, true);
+
+    assert_eq!(chunk.offset(), 0);
+    assert_eq!(chunk.length(), 4);
+    assert_eq!(chunk.name(), b"head");
+    let name_result = chunk.name_as_string();
+    assert!(name_result.is_ok());
+    assert_eq!(name_result.unwrap(), "head");
+    assert_eq!(chunk.chunk_type(), &ChunkType::Header);
+    assert_eq!(chunk.should_hash(), true);
+}
+
+#[test]
+fn test_chunk_position_display() {
+    let chunk = ChunkPosition {
+        offset: 0,
+        length: 4,
+        name: *b"head",
+        chunk_type: ChunkType::Header,
+        should_hash: true,
+    };
+
+    assert_eq!(
+        chunk.to_string(),
+        "Chunk(Header): head at offset 0 with length 4; hash: true"
+    );
+}
+
+#[test]
+fn test_chunk_type_display() {
+    assert_eq!(ChunkType::Header.to_string(), "Header");
+    assert_eq!(ChunkType::DirectoryEntry.to_string(), "Directory Entry");
+    assert_eq!(ChunkType::TableData.to_string(), "Table Data");
+}

--- a/c2pa-font-handler/src/chunks_test.rs
+++ b/c2pa-font-handler/src/chunks_test.rs
@@ -37,15 +37,7 @@ impl std::fmt::Display for ChunkType {
     }
 }
 
-impl ChunkTypeTrait for ChunkType {
-    fn should_hash(&self) -> bool {
-        match self {
-            ChunkType::Header => true,
-            ChunkType::DirectoryEntry => false,
-            ChunkType::TableData => true,
-        }
-    }
-}
+impl ChunkTypeTrait for ChunkType {}
 
 #[test]
 fn test_chunk_position() {

--- a/c2pa-font-handler/src/chunks_test.rs
+++ b/c2pa-font-handler/src/chunks_test.rs
@@ -16,9 +16,40 @@
 
 use super::*;
 
+/// A chunk type
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ChunkType {
+    /// Header
+    Header,
+    /// Directory entry
+    DirectoryEntry,
+    /// Table data
+    TableData,
+}
+
+impl std::fmt::Display for ChunkType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ChunkType::Header => write!(f, "Header"),
+            ChunkType::DirectoryEntry => write!(f, "Directory Entry"),
+            ChunkType::TableData => write!(f, "Table Data"),
+        }
+    }
+}
+
+impl ChunkTypeTrait for ChunkType {
+    fn should_hash(&self) -> bool {
+        match self {
+            ChunkType::Header => true,
+            ChunkType::DirectoryEntry => false,
+            ChunkType::TableData => true,
+        }
+    }
+}
+
 #[test]
 fn test_chunk_position() {
-    let chunk = ChunkPosition::new(0, 4, *b"head", ChunkType::Header, true);
+    let chunk = ChunkPosition::new(0, 4, *b"head", ChunkType::Header);
 
     assert_eq!(chunk.offset(), 0);
     assert_eq!(chunk.length(), 4);
@@ -27,7 +58,7 @@ fn test_chunk_position() {
     assert!(name_result.is_ok());
     assert_eq!(name_result.unwrap(), "head");
     assert_eq!(chunk.chunk_type(), &ChunkType::Header);
-    assert_eq!(chunk.should_hash(), true);
+    assert!(chunk.chunk_type().should_hash());
 }
 
 #[test]
@@ -37,12 +68,11 @@ fn test_chunk_position_display() {
         length: 4,
         name: *b"head",
         chunk_type: ChunkType::Header,
-        should_hash: true,
     };
 
     assert_eq!(
         chunk.to_string(),
-        "Chunk(Header): head at offset 0 with length 4; hash: true"
+        "Chunk(Header): head at offset 0 with length 4"
     );
 }
 

--- a/c2pa-font-handler/src/lib.rs
+++ b/c2pa-font-handler/src/lib.rs
@@ -49,6 +49,7 @@ use std::{
 use tag::FontTag;
 
 pub mod c2pa;
+pub mod chunks;
 pub mod data;
 pub mod error;
 pub(crate) mod magic;

--- a/c2pa-font-handler/src/magic.rs
+++ b/c2pa-font-handler/src/magic.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Monotype Imaging Inc.
+// Copyright 2024-2025 Monotype Imaging Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/c2pa-font-handler/src/magic.rs
+++ b/c2pa-font-handler/src/magic.rs
@@ -21,7 +21,7 @@ use super::error::FontIoError;
 /// Note that Embedded OpenType and MicroType Express formats cannot be detected
 /// with a simple magic-number sniff. Conceivably, EOT could be dealt with as a
 /// variation on SFNT, but MTX will needs more exotic handling.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Magic {
     /// 'OTTO' - OpenType
     OpenType = 0x4f54544f,

--- a/c2pa-font-handler/src/sfnt/font.rs
+++ b/c2pa-font-handler/src/sfnt/font.rs
@@ -345,6 +345,7 @@ impl ChunkReader for SfntFont {
             ChunkType::Header,
             true,
         ));
+        tracing::trace!("Header position information added");
         // Push the font directory information
         positions.push(ChunkPosition::new(
             SfntHeader::SIZE,
@@ -353,12 +354,16 @@ impl ChunkReader for SfntFont {
             ChunkType::DirectoryEntry,
             true,
         ));
+        tracing::trace!("Directory position information added");
 
         // And then go through each table entry and calculate the positions of
         // the table data.
         for entry in directory.physical_order() {
             match entry.tag() {
                 FontTag::C2PA => {
+                    tracing::trace!(
+                        "C2PA table found, adding positional information"
+                    );
                     positions.push(ChunkPosition::new(
                         entry.offset as usize,
                         entry.length as usize,
@@ -368,6 +373,7 @@ impl ChunkReader for SfntFont {
                     ));
                 }
                 FontTag::HEAD => {
+                    tracing::trace!("'head' table found, adding positional information, where excluding the checksum adjustment");
                     positions.push(ChunkPosition::new(
                         entry.offset() as usize,
                         8_usize,
@@ -391,6 +397,9 @@ impl ChunkReader for SfntFont {
                     ));
                 }
                 _ => {
+                    tracing::trace!(
+                        "Adding positional information for table data"
+                    );
                     positions.push(ChunkPosition::new(
                         entry.offset() as usize,
                         entry.length() as usize,

--- a/c2pa-font-handler/src/sfnt/font_test.rs
+++ b/c2pa-font-handler/src/sfnt/font_test.rs
@@ -483,3 +483,17 @@ fn test_sfnt_font_chunk_reader_tracing() {
     assert!(logs_contain("'head' table found, adding positional information, where excluding the checksum adjustment"));
     assert!(logs_contain("Adding positional information for table data"));
 }
+
+#[test]
+fn test_sfnt_chunk_type_display() {
+    assert_eq!(
+        SfntChunkType::HeaderDirectory.to_string(),
+        "HeaderDirectory"
+    );
+    assert_eq!(SfntChunkType::TableData.to_string(), "Table Data");
+    assert_eq!(
+        SfntChunkType::ChecksumAdjustment.to_string(),
+        "Checksum Adjustment"
+    );
+    assert_eq!(SfntChunkType::C2paTableData.to_string(), "C2PA Table Data");
+}

--- a/c2pa-font-handler/src/woff1/font.rs
+++ b/c2pa-font-handler/src/woff1/font.rs
@@ -16,6 +16,7 @@
 
 use std::{
     collections::BTreeMap,
+    fmt::Display,
     io::{Read, Seek},
 };
 
@@ -25,7 +26,7 @@ use super::{
     Table,
 };
 use crate::{
-    chunks::{ChunkPosition, ChunkReader, ChunkType},
+    chunks::{ChunkPosition, ChunkReader, ChunkTypeTrait},
     data::Data,
     error::FontIoError,
     tag::FontTag,
@@ -231,14 +232,59 @@ const WOFF_PRIVATE_DATA_CHUNK_NAME: FontTag = FontTag {
     data: *b"\x7F\x7F\x7FP",
 };
 
+/// WOFF chunk type
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WoffChunkType {
+    /// Header
+    Header,
+    /// Directory entry
+    DirectoryEntry,
+    /// Table data
+    TableData,
+    /// Metadata
+    Metadata,
+    /// Private data
+    ///
+    /// # Remarks
+    /// Currently, the thinking is to put the C2PA data in the private data,
+    /// but this may change.
+    Private,
+}
+
+impl Display for WoffChunkType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WoffChunkType::Header => write!(f, "Header"),
+            WoffChunkType::DirectoryEntry => write!(f, "Directory Entry"),
+            WoffChunkType::TableData => write!(f, "Table Data"),
+            WoffChunkType::Metadata => write!(f, "Metadata"),
+            WoffChunkType::Private => write!(f, "Private Data"),
+        }
+    }
+}
+
+impl ChunkTypeTrait for WoffChunkType {
+    /// Currently this assumes the private data of a WOFF font will be excluded,
+    /// but it is still a work in progress
+    fn should_hash(&self) -> bool {
+        match self {
+            // At the moment, the private part is the only section excluded from
+            // hashing
+            WoffChunkType::Private => false,
+            _ => true,
+        }
+    }
+}
+
 // NOTE: This is still a work in progress, as support C2PA in WOFF has not be
 // fleshed out yet
 impl ChunkReader for Woff1Font {
+    type ChunkType = WoffChunkType;
     type Error = FontIoError;
 
     fn get_chunk_positions(
         reader: &mut (impl Read + Seek + ?Sized),
-    ) -> Result<Vec<crate::chunks::ChunkPosition>, Self::Error> {
+    ) -> Result<Vec<ChunkPosition<Self::ChunkType>>, Self::Error> {
         let woff_header = Woff1Header::from_reader(reader)?;
         let size_to_read =
             woff_header.numTables as usize * Woff1DirectoryEntry::SIZE;
@@ -248,21 +294,19 @@ impl ChunkReader for Woff1Font {
             size_to_read,
         )?;
 
-        let mut positions: Vec<ChunkPosition> = Vec::new();
+        let mut positions: Vec<ChunkPosition<Self::ChunkType>> = Vec::new();
         positions.push(ChunkPosition::new(
             0,
             Woff1Header::SIZE,
             WOFF_HEADER_CHUNK_NAME.data,
-            ChunkType::Header,
-            true,
+            WoffChunkType::Header,
         ));
         tracing::trace!("Header position information added");
         positions.push(ChunkPosition::new(
-            Woff1Header::SIZE as usize,
+            Woff1Header::SIZE,
             size_to_read,
             WOFF_DIRECTORY_CHUNK_NAME.data,
-            ChunkType::DirectoryEntry,
-            true,
+            WoffChunkType::DirectoryEntry,
         ));
         tracing::trace!("Directory position information added");
 
@@ -272,8 +316,7 @@ impl ChunkReader for Woff1Font {
                 entry.offset() as usize,
                 entry.length() as usize,
                 entry.tag().data,
-                ChunkType::TableData,
-                true,
+                WoffChunkType::TableData,
             ));
             tracing::trace!("Table data position information added");
         }
@@ -284,8 +327,7 @@ impl ChunkReader for Woff1Font {
                 woff_header.metaOffset as usize,
                 woff_header.metaLength as usize,
                 WOFF_METADATA_CHUNK_NAME.data,
-                ChunkType::TableData,
-                true,
+                WoffChunkType::Metadata,
             ));
             tracing::trace!("Metadata position information added");
         }
@@ -296,9 +338,7 @@ impl ChunkReader for Woff1Font {
                 woff_header.privOffset as usize,
                 woff_header.privLength as usize,
                 WOFF_PRIVATE_DATA_CHUNK_NAME.data,
-                ChunkType::TableData,
-                false, /* Should we not hash the private part? Will this be
-                        * where we store C2PA? */
+                WoffChunkType::Private,
             ));
             tracing::trace!("Private data position information added");
         }

--- a/c2pa-font-handler/src/woff1/font_test.rs
+++ b/c2pa-font-handler/src/woff1/font_test.rs
@@ -408,3 +408,15 @@ fn test_woff_font_chunk_reader_tracing() {
     assert!(!logs_contain("Metadata position information added"));
     assert!(!logs_contain("Private data position information added"));
 }
+
+#[test]
+fn test_woff_chunk_type_display() {
+    assert_eq!(format!("{}", WoffChunkType::Header), "Header");
+    assert_eq!(
+        format!("{}", WoffChunkType::DirectoryEntry),
+        "Directory Entry"
+    );
+    assert_eq!(format!("{}", WoffChunkType::TableData), "Table Data");
+    assert_eq!(format!("{}", WoffChunkType::Metadata), "Metadata");
+    assert_eq!(format!("{}", WoffChunkType::Private), "Private Data");
+}

--- a/c2pa-font-handler/src/woff1/font_test.rs
+++ b/c2pa-font-handler/src/woff1/font_test.rs
@@ -394,3 +394,17 @@ fn test_woff_font_chunk_reader_metadata_private() {
     assert_eq!(private.chunk_type(), &ChunkType::TableData);
     assert!(!private.should_hash());
 }
+
+#[test]
+#[tracing_test::traced_test]
+fn test_woff_font_chunk_reader_tracing() {
+    // Load the font data bytes
+    let font_data = include_bytes!("../../../.devtools/font.woff");
+    let mut reader = std::io::Cursor::new(font_data);
+    let _ = Woff1Font::get_chunk_positions(&mut reader);
+    assert!(logs_contain("Header position information added"));
+    assert!(logs_contain("Directory position information added"));
+    assert!(logs_contain("Table data position information added"));
+    assert!(!logs_contain("Metadata position information added"));
+    assert!(!logs_contain("Private data position information added"));
+}

--- a/c2pa-font-handler/src/woff1/header.rs
+++ b/c2pa-font-handler/src/woff1/header.rs
@@ -38,7 +38,7 @@ use crate::{
 #[allow(non_snake_case)]
 pub struct Woff1Header {
     /// The 'magic' number for WOFF1 files (i.e., 0x774F4646 as defined in <https://www.w3.org/TR/2012/REC-WOFF-20121213/>).
-    pub(crate) signature: u32,
+    pub(crate) signature: Magic,
     /// The "sfnt flavor" of the font.
     pub(crate) flavor: u32,
     /// The length of the WOFF file.
@@ -69,7 +69,7 @@ pub struct Woff1Header {
 impl Default for Woff1Header {
     fn default() -> Self {
         Self {
-            signature: Magic::Woff as u32,
+            signature: Magic::Woff,
             flavor: 0,
             length: 0,
             numTables: 0,
@@ -98,7 +98,7 @@ impl FontDataRead for Woff1Header {
         reader: &mut T,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            signature: reader.read_u32::<BigEndian>()?,
+            signature: Magic::try_from(reader.read_u32::<BigEndian>()?)?,
             flavor: reader.read_u32::<BigEndian>()?,
             length: reader.read_u32::<BigEndian>()?,
             numTables: reader.read_u16::<BigEndian>()?,
@@ -138,7 +138,7 @@ impl FontDataWrite for Woff1Header {
         &self,
         dest: &mut TDest,
     ) -> Result<(), Self::Error> {
-        dest.write_u32::<BigEndian>(self.signature)?;
+        dest.write_u32::<BigEndian>(self.signature as u32)?;
         dest.write_u32::<BigEndian>(self.flavor)?;
         dest.write_u32::<BigEndian>(self.length)?;
         dest.write_u16::<BigEndian>(self.numTables)?;
@@ -157,7 +157,7 @@ impl FontDataWrite for Woff1Header {
 
 impl FontDataChecksum for Woff1Header {
     fn checksum(&self) -> Wrapping<u32> {
-        Wrapping(self.signature)
+        Wrapping(self.signature as u32)
             + Wrapping(self.flavor)
             + Wrapping(self.length)
             + u32_from_u16_pair(self.numTables, self.reserved)

--- a/c2pa-font-handler/src/woff1/header_test.rs
+++ b/c2pa-font-handler/src/woff1/header_test.rs
@@ -22,7 +22,7 @@ fn test_woff1_header_default() {
     assert!(matches!(
         woff,
         Woff1Header {
-            signature: 0x774f_4646,
+            signature: Magic::Woff,
             flavor: 0,
             length: 0,
             numTables: 0,
@@ -49,7 +49,7 @@ fn test_woff1_header_read_exact() {
     assert!(matches!(
         woff,
         Woff1Header {
-            signature: 0x774f_4646,
+            signature: Magic::Woff,
             flavor: 0x4f54_544f,
             length: 0x0000_0000_0000_0374,
             numTables: 0x000a,
@@ -93,7 +93,7 @@ fn test_woff1_header_read_exact_too_small_buffer() {
 #[test]
 fn test_woff1_header_write() {
     let woff = Woff1Header {
-        signature: 0x774f_4646,
+        signature: Magic::Woff,
         flavor: 0x4f54_544f,
         length: 0x0000_0000_0000_0374,
         numTables: 0x000a,
@@ -122,7 +122,7 @@ fn test_woff1_header_write() {
     assert!(matches!(
         woff,
         Woff1Header {
-            signature: 0x774f_4646,
+            signature: Magic::Woff,
             flavor: 0x4f54_544f,
             length: 0x0000_0000_0000_0374,
             numTables: 0x000a,
@@ -142,9 +142,9 @@ fn test_woff1_header_write() {
 #[test]
 fn test_woff1_header_checksum() {
     let woff = Woff1Header {
-        signature: 0x0000_0000_774f_4646,
-        flavor: 0x0000_0000_4f54_544f,
-        length: 0x0000_0000_0000_0374,
+        signature: Magic::Woff,
+        flavor: 0x4f54_544f,
+        length: 0x0000_0374,
         numTables: 0x0000_000a,
         reserved: 0x0000_0000,
         totalSfntSize: 0x0000_0000_0000_0424,
@@ -174,7 +174,7 @@ fn test_woff1_header_checksum() {
 #[test]
 fn test_woff1_header_num_tables() {
     let woff = Woff1Header {
-        signature: 0,
+        signature: Magic::Woff,
         flavor: 0,
         length: 0,
         numTables: 0x000a,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
-# @copyright 2024 Monotype Imaging Inc.
+# @copyright 2024-2025 Monotype Imaging Inc.
 #  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -17,4 +17,4 @@
 # @brief Rust toolchain configuration file.
 #
 [toolchain]
-channel = "1.75"
+channel = "1.82"


### PR DESCRIPTION
<!--  Title should use the format: "ISSUE-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/ISSUE-123/featureName"  -->
<!--        Branch names for Bugs: "fix/ISSUE-123/bugFixName"       -->
# Issue(s)

- C2PA-629

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [X] **Merge Commit** will be updated with `(MAJOR)` | `(MINOR)` when appropriate
- [X] **PR labeled** appropriately
- [X] Changes include a single fix/feature
- [X] **Documentation** updated:
  - [X] Developer documentation (ReadMe files)
  - [X] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [X] **Test case(s)** added
  - [X] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

Adds a `ChunkReader` trait and a `ChunkTypeTrait` to allow for reading positions of various chunks in a font. This is implemented for SFNT and the WOFF basis, with two chunk types:

- `SfntChunkType`
- `WoffChunkType`

These allow for the different sections to be labeled. 

# Verification Instructions
<!-- Instructions for checking or testing this change. -->

To test this out, you should be able to use the `feature/C2PA-637/useC2paFontHandlerChunkReader` branch from https://github.com/Monotype/c2pa-rs with a local setup. Using the updated SDK, you should be able to use it to sign a font and it should validate/verify. I also had a local copy of the https://github.com/Monotype/c2patool with the `monotype/fontSupport` branch with local changes to include the local c2pa-rs and this repo. 