### PR TITLE
release: initial support for compression for WOFF and update tokio dependency for vulnerability report

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -21,6 +21,7 @@
     "byteorder",
     "cdef",
     "cksum",
+    "decompressor",
     "DSIG",
     "flate",
     "fullword",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -613,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "clap",
+ "flate2",
  "serde",
  "serde_json",
  "thiserror",
@@ -135,6 +136,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+dependencies = [
+ "shlex",
 ]
 
 [[package]]
@@ -184,10 +194,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "libz-ng-sys",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "gimli"
@@ -226,6 +265,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
+name = "libz-ng-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7118c2c2a3c7b6edc279a8b19507672b9c4d716f95e671172dfa4e23f9fd824"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,9 +307,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -465,6 +514,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ anyhow = { version = "1.0.94" }
 byteorder = { version = "1.5.0" }
 bytes = { version = "1.9.0" }
 clap = { version = "4.5.23", features = ["derive"] }
+flate2 = { version = "1.1.0", features = ["zlib-ng"], default-features = false }
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = { version = "1.0.139" }
 thiserror = { version = "2.0.6" }

--- a/c2pa-font-handler/Cargo.toml
+++ b/c2pa-font-handler/Cargo.toml
@@ -25,12 +25,15 @@ license = "Apache-2.0"
 
 [features]
 default = []
-woff = []
+flate = ["dep:flate2"]
+compression = ["flate"]
+woff = [ "compression" ]
 
 [dependencies]
 anyhow.workspace = true
 byteorder.workspace = true
 bytes.workspace = true
+flate2 = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/c2pa-font-handler/ReadMe.md
+++ b/c2pa-font-handler/ReadMe.md
@@ -1,5 +1,6 @@
 # Font I/O
 
+- [Features](#features)
 - [Examples](#examples)
 
 This crate was brought in and adapted from the implementation found in [font_io.rs](https://github.com/Monotype/c2pa-rs/blob/monotype/fontSupport/sdk/src/asset_handlers/font_io.rs) and [sfnt_io.rs](https://github.com/Monotype/c2pa-rs/blob/monotype/fontSupport/sdk/src/asset_handlers/sfnt_io.rs) in the Monotype fork of the `c2pa-rs` repository.
@@ -7,6 +8,16 @@ This crate was brought in and adapted from the implementation found in [font_io.
 The use of "font I/O" is a bit strong, as it doesn't really do much at the moment. It has the ability read in a font and write it back out ensuring no new tables were added/removed. And with the use of the `FontDSIGStubber` trait, the font can be updated to have a stub or fake DSIG table.
 
 For more information, check out [lib.rs](./src/lib.rs).
+
+## Features
+
+There are a few features available for this crate:
+
+Feature|Note|On by Default
+-|-|-
+`flate`|Compiles the `flate2` crate|No
+`compression`|Turns on support for compression, using the `flate` feature|No
+`woff`|Turns on support for WOFF fonts (this is currently a work in progress)|No
 
 ## Examples
 

--- a/c2pa-font-handler/src/compression.rs
+++ b/c2pa-font-handler/src/compression.rs
@@ -1,0 +1,96 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Compression support for fonts (mostly WOFF1/WOFF2).
+//!
+//! Currently the only supported compression is Zlib.
+
+use std::io::{Read, Write};
+#[cfg(feature = "flate")]
+mod flate2;
+#[cfg(feature = "flate")]
+pub use flate2::ZlibCompression;
+
+/// Errors related to compression.
+#[derive(Debug, thiserror::Error)]
+pub enum CompressionError {
+    /// A compression error with the flate2 library.
+    #[error(transparent)]
+    Flate2CompressError(#[from] ::flate2::CompressError),
+    /// A decompression error with the flate2 library.
+    #[error(transparent)]
+    Flate2DecompressError(#[from] ::flate2::DecompressError),
+    /// General compression error.
+    #[error("General compression error: {0}")]
+    General(String),
+    /// An error occurred while reading or writing data.
+    #[error(transparent)]
+    StdIoError(#[from] std::io::Error),
+}
+
+/// A trait representing a data compressor.
+pub trait Compressor {
+    /// The error type returned by the compressor.
+    type Error: Into<CompressionError>;
+
+    /// The type of writer used by the compressor.
+    type Stream: Write + Read;
+
+    /// The type of encoder used by the compressor.
+    type Encoder: Encoder<Error = Self::Error, Stream = Self::Stream>;
+
+    /// Compresses the given data.
+    fn compress<T: AsRef<[u8]>>(
+        &self,
+        data: T,
+        destination: Self::Stream,
+    ) -> Result<Self::Stream, Self::Error>;
+}
+
+/// A trait representing a data decompressor.
+pub trait Decompressor {
+    /// The error type returned by the decompressor.
+    type Error: Into<CompressionError>;
+
+    /// The type of writer used by the decompressor.
+    type Stream: Write + Read;
+
+    /// The type of decoder used by the decompressor.
+    type Decoder: Decoder<Error = Self::Error, Stream = Self::Stream>;
+
+    /// Decompresses the given data.
+    fn decompress<T: AsMut<[u8]>>(
+        &self,
+        data: T,
+        destination: Self::Stream,
+    ) -> Result<Self::Stream, Self::Error>;
+}
+
+/// Describes an encoder to use during compression.
+pub trait Encoder: Write {
+    /// The error type returned by the encoder.
+    type Error: Into<CompressionError>;
+
+    /// The type of writer used by the encoder.
+    type Stream: Write + Read;
+}
+
+/// Describes a decoder to use during decompression.
+pub trait Decoder: Write + Read {
+    /// The error type returned by the decoder.
+    type Error: Into<CompressionError>;
+
+    /// The type of writer used by the decoder.
+    type Stream: Write + Read;
+}

--- a/c2pa-font-handler/src/compression/flate2.rs
+++ b/c2pa-font-handler/src/compression/flate2.rs
@@ -1,0 +1,120 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Compression implementations using the flate2 library.
+//!
+//! The following example shows how to use the compression support:
+//!
+//! ```rust
+//! use std::io::Cursor;
+//!
+//! use c2pa_font_handler::compression::{
+//!     Compressor, Decompressor, ZlibCompression,
+//! };
+//!
+//! // Compress the data
+//! let data = b"Hello, world!";
+//! // Create a new ZlibCompressor
+//! let zlib_compression = ZlibCompression::default();
+//! let result = zlib_compression.compress(data, Cursor::new(Vec::new()));
+//! assert!(result.is_ok());
+//! // Get the inner Vec<u8> to use as a compressed data
+//! let compressed_data = result.unwrap().into_inner();
+//! // Decompress the data
+//! let result =
+//!     zlib_compression.decompress(compressed_data, Cursor::new(Vec::new()));
+//! assert!(result.is_ok());
+//! let original = result.unwrap();
+//! // The original data should be equal to the decompressed data
+//! assert_eq!(data, original.get_ref().as_slice());
+//! ```
+
+use std::io::{Read, Write};
+
+use super::{CompressionError, Compressor, Decoder, Decompressor, Encoder};
+
+// Implementation of the Encoder trait for flate2::write::ZlibEncoder
+impl<T: Write + Read> Encoder for flate2::write::ZlibEncoder<T> {
+    type Error = CompressionError;
+    type Stream = T;
+}
+
+// Implementation of the Decoder trait for flate2::write::ZlibDecoder
+impl<T: Write + Read> Decoder for flate2::write::ZlibDecoder<T> {
+    type Error = CompressionError;
+    type Stream = T;
+}
+
+/// A compressor using the flate2 library.
+#[derive(Default)]
+pub struct ZlibCompression<T>
+where
+    T: Write + Read,
+{
+    stream_marker: std::marker::PhantomData<T>,
+    compression_settings: flate2::Compression,
+}
+
+impl<T> ZlibCompression<T>
+where
+    T: Write + Read,
+{
+    /// Creates a new ZlibCompressor with the specified compression settings.
+    pub fn new(compression_settings: flate2::Compression) -> Self {
+        ZlibCompression {
+            stream_marker: Default::default(),
+            compression_settings,
+        }
+    }
+}
+
+impl<T: Write + Read> Compressor for ZlibCompression<T> {
+    type Encoder = flate2::write::ZlibEncoder<T>;
+    type Error = CompressionError;
+    type Stream = T;
+
+    fn compress<D: AsRef<[u8]>>(
+        &self,
+        data: D,
+        destination: Self::Stream,
+    ) -> Result<Self::Stream, Self::Error> {
+        let mut encoder =
+            Self::Encoder::new(destination, self.compression_settings);
+        encoder.write_all(data.as_ref())?;
+        let compressed_data = encoder.finish()?;
+        Ok(compressed_data)
+    }
+}
+
+impl<T: Write + Read> Decompressor for ZlibCompression<T> {
+    type Decoder = flate2::write::ZlibDecoder<T>;
+    type Error = CompressionError;
+    type Stream = T;
+
+    fn decompress<D: AsMut<[u8]>>(
+        &self,
+        data: D,
+        destination: Self::Stream,
+    ) -> Result<Self::Stream, Self::Error> {
+        let mut decoder = Self::Decoder::new(destination);
+        let mut data = data;
+        decoder.write_all(data.as_mut())?;
+        let decompressed_data = decoder.finish()?;
+        Ok(decompressed_data)
+    }
+}
+
+#[cfg(test)]
+#[path = "flate2_test.rs"]
+mod tests;

--- a/c2pa-font-handler/src/compression/flate2_test.rs
+++ b/c2pa-font-handler/src/compression/flate2_test.rs
@@ -1,0 +1,62 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Tests for the flate2 compression support
+
+use std::io::Cursor;
+
+use flate2::Compression;
+
+use super::*;
+
+#[test]
+fn compress() {
+    let data = b"Hello, world!";
+    // And use it to build a flate2 compressor
+    let zlib_compression = ZlibCompression::default();
+
+    // Create a destination to compress to
+    let destination = Cursor::new(Vec::new());
+    // And compress the data
+    let result = zlib_compression.compress(data, destination);
+    assert!(result.is_ok());
+    let destination = result.unwrap().into_inner();
+
+    // We will setup to decode for a round trip test
+    let original = Cursor::new(Vec::new());
+    let result = zlib_compression.decompress(destination, original);
+    assert!(result.is_ok());
+    let original = result.unwrap();
+    assert_eq!(data, original.get_ref().as_slice());
+}
+
+#[test]
+fn compression_with_custom_settings() {
+    let data = b"Hello, world!";
+    // Create a new ZlibCompressor with custom settings
+    let zlib_compression = ZlibCompression::new(Compression::fast());
+    // Create a destination to compress to
+    let destination = Cursor::new(Vec::new());
+    // And compress the data
+    let result = zlib_compression.compress(data, destination);
+    assert!(result.is_ok());
+    let destination = result.unwrap().into_inner();
+
+    // We will setup to decode for a round trip test
+    let original = Cursor::new(Vec::new());
+    let result = zlib_compression.decompress(destination, original);
+    assert!(result.is_ok());
+    let original = result.unwrap();
+    assert_eq!(data, original.get_ref().as_slice());
+}

--- a/c2pa-font-handler/src/lib.rs
+++ b/c2pa-font-handler/src/lib.rs
@@ -50,6 +50,8 @@ use tag::FontTag;
 
 pub mod c2pa;
 pub mod chunks;
+#[cfg(feature = "compression")]
+pub mod compression;
 pub mod data;
 pub mod error;
 pub(crate) mod magic;


### PR DESCRIPTION
# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

This is a release to mainly address the tokio upgrade. But along with it comes the start of the compression support.

# Verification Instructions
<!-- Instructions for checking or testing this change. -->