### PR TITLE
C2PA-695: Correctly update WOFF header for length, numTables, and totalSfntSize

### DIFF
--- a/c2pa-font-handler/src/woff1/font.rs
+++ b/c2pa-font-handler/src/woff1/font.rs
@@ -259,6 +259,7 @@ impl MutFontDataWrite for Woff1Font {
         // We will need to keep up with the original checksum for the C2PA table
         // to write it later in the directory entry
         let mut original_checksum = 0;
+        let mut c2pa_uncompressed_data_length = 0;
         // If we have a C2PA table, we will attempt to compress it
         let c2pa_data = self
             .tables
@@ -280,6 +281,8 @@ impl MutFontDataWrite for Woff1Font {
                     origLength: c2pa_table.length(),
                     origChecksum: original_checksum,
                 });
+                c2pa_uncompressed_data_length = c2pa_table.length();
+
                 running_offset += align_to_four(c2pa_table.compressed_length());
                 Ok::<_, FontIoError>(c2pa_table)
             })
@@ -298,9 +301,29 @@ impl MutFontDataWrite for Woff1Font {
 
         // If we have private data, update the header
         if let Some(private) = &self.private_data {
+            let private_length = private.len();
             neo_header.privOffset = running_offset;
-            neo_header.privLength = private.len();
+            neo_header.privLength = private_length;
+            running_offset += align_to_four(private_length);
         }
+
+        // Update the header with the new length of the entire file
+        neo_header.length = running_offset;
+
+        // TODO: look at this more!!!
+        // We need to update the total SFNT size, should it incorporate the
+        // compressed size of the C2PA table?
+        if c2pa_uncompressed_data_length > 0 {
+            neo_header.totalSfntSize = self.header.totalSfntSize // The original size
+                + Woff1DirectoryEntry::SIZE as u32 // Plus the size of one new directory entry
+                + c2pa_uncompressed_data_length; // The size of the uncompressed
+                                                 // data for the C2PA table
+        }
+
+        // Update the number of tables in the header, which will include the
+        // C2PA table
+        neo_header.numTables = neo_directory.entries().len() as u16;
+
         // Update ourselves with the new header and directory
         self.header = neo_header;
         self.directory = neo_directory;

--- a/c2pa-font-handler/src/woff1/font.rs
+++ b/c2pa-font-handler/src/woff1/font.rs
@@ -268,7 +268,6 @@ impl MutFontDataWrite for Woff1Font {
             .map(|c2pa| {
                 original_checksum = c2pa.checksum().0;
                 let mut data_to_compress = Vec::new();
-                tracing::warn!("Uncompressed C2PA table size: {}", c2pa.len());
                 c2pa.write(&mut data_to_compress)?;
                 let c2pa_table = Self::optimize_table_data(
                     &mut Cursor::new(data_to_compress),
@@ -319,7 +318,6 @@ impl MutFontDataWrite for Woff1Font {
             for table in neo_directory.entries() {
                 total_sfnt_size += align_to_four(table.origLength);
             }
-            tracing::trace!("New total SFNT size: {total_sfnt_size}",);
             total_sfnt_size
         };
 


### PR DESCRIPTION
<!--  Title should use the format: "ISSUE-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/ISSUE-123/featureName"  -->
<!--        Branch names for Bugs: "fix/ISSUE-123/bugFixName"       -->
# Issue(s)

- C2PA-695

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [X] **Merge Commit** will be updated with `(MAJOR)` | `(MINOR)` when appropriate
- [X] **PR labeled** appropriately
- [X] Changes include a single fix/feature
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [X] **Test case(s)** added
  - [X] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

Previously the WOFF header was not updated correctly to have the correct:

- numTables - this now includes the new C2PA table
- length - this now has the correct length of the entire WOFF file
- totalSfntSize - this was previously incorrectly calculating using WOFF header|directory sizes, now uses SFNT instead

# Verification Instructions
<!-- Instructions for checking or testing this change. -->

The `woff` example has the ability to write the input WOFF font to a new file adding a remote URI reference (i.e., adding a `C2PA` table).