### PR TITLE
C2PA-688: Ability to convert a WOFF to SFNT

### DIFF
--- a/c2pa-font-handler/src/data.rs
+++ b/c2pa-font-handler/src/data.rs
@@ -22,7 +22,7 @@ use std::{
 
 use crate::{
     error::FontIoError, utils, FontDataChecksum, FontDataExactRead,
-    FontDataWrite, FontTable,
+    FontDataWrite, FontTable, FontTableReader,
 };
 
 /// Generic data structure for reading and writing data (e.g. OTF/WOFF1 tables).
@@ -45,6 +45,13 @@ impl Data {
     }
 }
 
+impl<'a> FontTableReader<'a> for Data {
+    type Error = FontIoError;
+
+    fn get_reader(&'a self) -> Result<impl Read + Seek + 'a, Self::Error> {
+        Ok(std::io::Cursor::new(self.data.as_slice()))
+    }
+}
 /*
 impl<'a> Data {
     pub fn reader(&'a self) -> impl Read + Seek + 'a {

--- a/c2pa-font-handler/src/data.rs
+++ b/c2pa-font-handler/src/data.rs
@@ -52,13 +52,6 @@ impl<'a> FontTableReader<'a> for Data {
         Ok(std::io::Cursor::new(self.data.as_slice()))
     }
 }
-/*
-impl<'a> Data {
-    pub fn reader(&'a self) -> impl Read + Seek + 'a {
-        std::io::Cursor::new(self.data.as_slice())
-    }
-}
-*/
 
 impl FontDataExactRead for Data {
     type Error = FontIoError;

--- a/c2pa-font-handler/src/data.rs
+++ b/c2pa-font-handler/src/data.rs
@@ -27,7 +27,7 @@ use crate::{
 
 /// Generic data structure for reading and writing data (e.g. OTF/WOFF1 tables).
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Data {
     /// The data
     pub(crate) data: Vec<u8>,
@@ -44,6 +44,14 @@ impl Data {
         self.data = data;
     }
 }
+
+/*
+impl<'a> Data {
+    pub fn reader(&'a self) -> impl Read + Seek + 'a {
+        std::io::Cursor::new(self.data.as_slice())
+    }
+}
+*/
 
 impl FontDataExactRead for Data {
     type Error = FontIoError;

--- a/c2pa-font-handler/src/error.rs
+++ b/c2pa-font-handler/src/error.rs
@@ -77,6 +77,9 @@ pub enum FontIoError {
     /// An error occurred while generating a string from UTF-8 bytes.
     #[error("Error occurred while generating a string from UTF-8 bytes: {0}")]
     StringFromUtf8(#[from] std::string::FromUtf8Error),
+    /// The table associated with the tag was not found.
+    #[error("The font table was not found for tag: {0}")]
+    TableNotFound(FontTag),
     /// When determining the type of font, the magic number was not recognized.
     #[error("An unknown magic number was encountered: {0}")]
     UnknownMagic(u32),

--- a/c2pa-font-handler/src/error.rs
+++ b/c2pa-font-handler/src/error.rs
@@ -71,6 +71,9 @@ pub enum FontIoError {
     /// The font table is truncated.
     #[error("The font table is truncated: {0}")]
     LoadTableTruncated(FontTag),
+    /// There were no tables found in the font.
+    #[error("No tables were found in the font.")]
+    NoTablesFound,
     /// Save errors.
     #[error("Error saving the font: {0}")]
     SaveError(#[from] FontSaveError),

--- a/c2pa-font-handler/src/lib.rs
+++ b/c2pa-font-handler/src/lib.rs
@@ -172,6 +172,14 @@ pub trait FontTable: FontDataChecksum + FontDataWrite {
     }
 }
 
+/// A trait for getting a reader for a font table.
+pub trait FontTableReader<'a> {
+    /// The error type for reading the table.
+    type Error: Into<crate::error::FontIoError>;
+    /// Returns a reader for the font table data.
+    fn get_reader(&'a self) -> Result<impl Read + Seek + 'a, Self::Error>;
+}
+
 /// Represents a font.
 pub trait Font: FontDataRead + MutFontDataWrite {
     /// The header type for the font.

--- a/c2pa-font-handler/src/sfnt/font.rs
+++ b/c2pa-font-handler/src/sfnt/font.rs
@@ -41,6 +41,12 @@ use crate::{
 };
 
 /// Implementation of an SFNT font.
+///
+/// # Remarks
+/// If the 'woff' feature is enabled, this type can also be created from a
+/// a Woff1Font using the `TryFrom` trait. This is not intended to be used
+/// to produce production-ready SFNT fonts, but serves as a way to utilize
+/// thumbnails for WOFF fonts.
 #[derive(Default)]
 pub struct SfntFont {
     header: SfntHeader,

--- a/c2pa-font-handler/src/sfnt/font.rs
+++ b/c2pa-font-handler/src/sfnt/font.rs
@@ -65,7 +65,12 @@ impl TryFrom<crate::woff1::font::Woff1Font> for SfntFont {
         // Copy over fields as appropriate (you may want to copy more fields)
         let sfnt_header = SfntHeader {
             sfntVersion: woff.header.flavor.try_into()?,
-            numTables: woff.directory.entries().len() as u16,
+            numTables: woff
+                .directory
+                .entries()
+                .iter()
+                .filter(|e| e.tag != FontTag::C2PA)
+                .count() as u16,
             ..Default::default()
         };
         // You may want to set searchRange, entrySelector, rangeShift here as
@@ -128,9 +133,7 @@ impl TryFrom<crate::woff1::font::Woff1Font> for SfntFont {
                 WoffNamedTable::C2PA(_table) => {
                     // C2PA table belongs to the WOFF font, so no need to add it
                     // to the SFNT font.
-                    tracing::trace!(
-                        "Converting WOFF C2PA table to SFNT C2PA table"
-                    );
+                    tracing::trace!("WOFF C2PA will not be added to SFNT font");
                     //SfntNamedTable::C2PA(table.clone())
                 }
             };

--- a/c2pa-font-handler/src/sfnt/font_test.rs
+++ b/c2pa-font-handler/src/sfnt/font_test.rs
@@ -497,3 +497,163 @@ fn test_sfnt_chunk_type_display() {
     );
     assert_eq!(SfntChunkType::C2paTableData.to_string(), "C2PA Table Data");
 }
+
+#[cfg(feature = "woff")]
+#[test]
+fn test_try_from_woff_to_sfnt() {
+    // Simulate a WOFF font
+
+    use crate::woff1::font::Woff1Font;
+    let woff_data = vec![
+        0x77, 0x4f, 0x46, 0x46, // Signature
+        0x4f, 0x54, 0x54, 0x4f, // Flavor
+        0x00, 0x00, 0x00, 0x48, // Length
+        0x00, 0x01, 0x00, 0x00, // Number of tables + Reserved
+        0x00, 0x00, 0x00, 0x18, // Total sfnt size
+        0x00, 0x00, 0x00, 0x00, // Major version + Minor version
+        0x00, 0x00, 0x00, 0x44, // Metadata Offset
+        0x00, 0x00, 0x00, 0x04, // Metadata Length
+        0x00, 0x00, 0x00, 0x04, // Metadata Original Length
+        0x00, 0x00, 0x00, 0x00, // Private Offset
+        0x00, 0x00, 0x00, 0x00, // Private Length
+        0x74, 0x65, 0x73, 0x74, // Directory entry - tag (test)
+        0x00, 0x00, 0x00, 0x40, // Directory entry - offset
+        0x00, 0x00, 0x00, 0x04, // Directory entry - comp length
+        0x00, 0x00, 0x00, 0x04, // Directory entry - orig length
+        0x00, 0x00, 0x00, 0x00, // Directory entry - orig checksum
+        0x04, 0x03, 0x02, 0x01, // 'test' table
+        0x77, 0x55, 0x33, 0x58, // Metadata
+    ];
+    let woff_font =
+        Woff1Font::from_reader(&mut std::io::Cursor::new(woff_data.clone()))
+            .unwrap();
+    let sfnt_font_result: Result<SfntFont, _> = woff_font.try_into();
+    assert!(sfnt_font_result.is_ok());
+    let sfnt_font = sfnt_font_result.unwrap();
+    assert_eq!(sfnt_font.header.sfntVersion as u32, 0x4f54544f);
+    assert_eq!(sfnt_font.header.num_tables(), 1);
+    assert!(sfnt_font.contains_table(&FontTag::new(*b"test")));
+    let table = sfnt_font.table(&FontTag::new(*b"test"));
+    assert!(table.is_some());
+    let table = table.unwrap();
+    assert_eq!(table.len(), 4);
+}
+
+#[cfg(feature = "woff")]
+#[test]
+#[tracing_test::traced_test]
+fn test_try_from_woff_to_sfnt_with_c2pa() {
+    use crate::woff1::font::Woff1Font;
+    // Simulate a WOFF font
+    let woff_data = vec![
+        0x77, 0x4f, 0x46, 0x46, // Signature
+        0x4f, 0x54, 0x54, 0x4f, // Flavor
+        0x00, 0x00, 0x00, 0x88, // Length (136 bytes)
+        0x00, 0x02, 0x00, 0x00, // Number of tables + Reserved
+        /* Total sfnt size: 96: (12[sfnt header] + 16*2[table
+         * directory entries] + (20+26+2padding)[c2pa] + 4[text]) */
+        0x00, 0x00, 0x00, 0x60, // Total sfnt size
+        0x00, 0x00, 0x00, 0x00, // Major version + Minor version
+        0x00, 0x00, 0x00, 0x00, // Metadata Offset
+        0x00, 0x00, 0x00, 0x00, // Metadata Length
+        0x00, 0x00, 0x00, 0x00, // Metadata Original Length
+        0x00, 0x00, 0x00, 0x00, // Private Offset
+        0x00, 0x00, 0x00, 0x00, // Private Length
+        0x43, 0x32, 0x50, 0x41, // Directory entry - tag (C2PA)
+        0x00, 0x00, 0x00, 0x58, // Directory entry - offset
+        0x00, 0x00, 0x00, 0x2e, // Directory entry - comp length
+        0x00, 0x00, 0x00, 0x2e, // Directory entry - orig length
+        0x56, 0x54, 0x0c, 0x33, // Directory entry - orig checksum
+        0x74, 0x65, 0x73, 0x74, // Directory entry - tag (text)
+        0x00, 0x00, 0x00, 0x54, // Directory entry - offset
+        0x00, 0x00, 0x00, 0x04, // Directory entry - comp length
+        0x00, 0x00, 0x00, 0x04, // Directory entry - orig length
+        0x40, 0x30, 0x02, 0x01, // Directory entry - orig checksum
+        0x04, 0x03, 0x02, 0x01, // 'test' table
+        /* 'C2PA' table */
+        0x00, 0x00, 0x00, 0x01, // major/minor version
+        0x00, 0x00, 0x00, 0x14, // manifest URI offset
+        0x00, 0x1a, 0x00, 0x00, // manifest URI length + reserved
+        0x00, 0x00, 0x00, 0x00, // content credential offset
+        0x00, 0x00, 0x00, 0x00, // content credential length
+        /* active manifest URI - http://localhost:3001/c2pa\0\0 */
+        0x68, 0x74, 0x74, 0x70, //
+        0x3a, 0x2f, 0x2f, 0x6c, //
+        0x6f, 0x63, 0x61, 0x6c, //
+        0x68, 0x6f, 0x73, 0x74, //
+        0x3a, 0x33, 0x30, 0x30, //
+        0x31, 0x2f, 0x63, 0x32, //
+        0x70, 0x61, 0x00, 0x00, // Last bit with 2 bytes of padding
+    ];
+
+    let woff_font =
+        Woff1Font::from_reader(&mut std::io::Cursor::new(woff_data.clone()))
+            .unwrap();
+    let sfnt_font_result: Result<SfntFont, _> = woff_font.try_into();
+    assert!(sfnt_font_result.is_ok());
+    let sfnt_font = sfnt_font_result.unwrap();
+    assert_eq!(sfnt_font.header.sfntVersion as u32, 0x4f54544f);
+    assert_eq!(sfnt_font.header.num_tables(), 1);
+    assert!(sfnt_font.contains_table(&FontTag::new(*b"test")));
+    let table = sfnt_font.table(&FontTag::new(*b"test"));
+    assert!(table.is_some());
+    let table = table.unwrap();
+    assert_eq!(table.len(), 4);
+    assert!(logs_contain("WOFF C2PA will not be added to SFNT font"));
+}
+
+#[cfg(feature = "woff")]
+#[test]
+#[tracing_test::traced_test]
+fn test_try_from_woff_to_sfnt_with_compression() {
+    use crate::woff1::font::Woff1Font;
+    // Simulate a WOFF font
+    let woff_data = vec![
+        0x77, 0x4f, 0x46, 0x46, // Signature
+        0x4f, 0x54, 0x54, 0x4f, // Flavor
+        0x00, 0x00, 0x00, 0x70, // Length (112 bytes)
+        0x00, 0x02, 0x00, 0x00, // Number of tables + Reserved
+        /* Total sfnt size: 96: (12[sfnt header] + 16*2[table
+         * directory entries] + (20+26+2padding)[c2c2] + 4[text]) */
+        0x00, 0x00, 0x00, 0x60, // Total sfnt size
+        0x00, 0x00, 0x00, 0x00, // Major version + Minor version
+        0x00, 0x00, 0x00, 0x00, // Metadata Offset
+        0x00, 0x00, 0x00, 0x00, // Metadata Length
+        0x00, 0x00, 0x00, 0x00, // Metadata Original Length
+        0x00, 0x00, 0x00, 0x00, // Private Offset
+        0x00, 0x00, 0x00, 0x00, // Private Length
+        0x43, 0x32, 0x43, 0x32, // Directory entry - tag (C2C2)
+        0x00, 0x00, 0x00, 0x58, // Directory entry - offset
+        0x00, 0x00, 0x00, 0x17, // Directory entry - comp length
+        0x00, 0x00, 0x00, 0x2e, // Directory entry - orig length
+        0x51, 0x6b, 0x21, 0x35, // Directory entry - orig checksum
+        0x74, 0x65, 0x73, 0x74, // Directory entry - tag (text)
+        0x00, 0x00, 0x00, 0x54, // Directory entry - offset
+        0x00, 0x00, 0x00, 0x04, // Directory entry - comp length
+        0x00, 0x00, 0x00, 0x04, // Directory entry - orig length
+        0x40, 0x30, 0x02, 0x01, // Directory entry - orig checksum
+        0x04, 0x03, 0x02, 0x01, // 'test' table
+        /* 'C2C2' compressed table */
+        0x78, 0x9c, 0x63, 0x60, // 120, 156, 99, 96
+        0x60, 0x60, 0x64, 0x60, // 96, 96, 100, 96
+        0x60, 0x10, 0x61, 0x90, // 96, 16, 97, 144
+        0x62, 0x80, 0x03, 0x03, // 98, 128, 3, 3
+        0x9c, 0x00, 0x00, 0x48, // 156, 0, 0, 72
+        0xf7, 0x05, 0x10, 0x00, // 247, 5, 16, 0
+    ];
+
+    let woff_font =
+        Woff1Font::from_reader(&mut std::io::Cursor::new(woff_data.clone()))
+            .unwrap();
+    let sfnt_font_result: Result<SfntFont, _> = woff_font.try_into();
+    assert!(sfnt_font_result.is_ok());
+    let sfnt_font = sfnt_font_result.unwrap();
+    assert_eq!(sfnt_font.header.sfntVersion as u32, 0x4f54544f);
+    assert_eq!(sfnt_font.header.num_tables(), 2);
+    assert!(sfnt_font.contains_table(&FontTag::new(*b"test")));
+    let table = sfnt_font.table(&FontTag::new(*b"test"));
+    assert!(table.is_some());
+    let table = table.unwrap();
+    assert_eq!(table.len(), 4);
+    assert!(!logs_contain("WOFF C2PA will not be added to SFNT font"));
+}

--- a/c2pa-font-handler/src/woff1/font.rs
+++ b/c2pa-font-handler/src/woff1/font.rs
@@ -52,7 +52,7 @@ pub struct Woff1Font {
 impl Woff1Font {
     /// Read and decompress a table from the WOFF1 font, for the
     /// given directory entry.
-    pub(crate) fn decompress_table<R: Read + Seek + ?Sized>(
+    pub(crate) fn decompress_table_from_stream<R: Read + Seek + ?Sized>(
         entry: &Woff1DirectoryEntry,
         reader: &mut R,
     ) -> Result<NamedTable, FontIoError> {
@@ -176,7 +176,7 @@ impl FontDataRead for Woff1Font {
             let table = if entry.compLength < entry.origLength
                 && entry.tag == FontTag::C2PA
             {
-                Self::decompress_table(entry, reader)?
+                Self::decompress_table_from_stream(entry, reader)?
             } else {
                 // Read in the table data
                 NamedTable::from_reader_exact(

--- a/c2pa-font-handler/src/woff1/font.rs
+++ b/c2pa-font-handler/src/woff1/font.rs
@@ -52,7 +52,7 @@ pub struct Woff1Font {
 impl Woff1Font {
     /// Read and decompress a table from the WOFF1 font, for the
     /// given directory entry.
-    fn decompress_table<R: Read + Seek + ?Sized>(
+    pub(crate) fn decompress_table<R: Read + Seek + ?Sized>(
         entry: &Woff1DirectoryEntry,
         reader: &mut R,
     ) -> Result<NamedTable, FontIoError> {

--- a/c2pa-font-handler/src/woff1/table/named_table.rs
+++ b/c2pa-font-handler/src/woff1/table/named_table.rs
@@ -19,6 +19,7 @@ use std::io::{Read, Seek, Write};
 use crate::{
     data::Data, error::FontIoError, sfnt::table::TableC2PA, tag::FontTag,
     FontDataChecksum, FontDataExactRead, FontDataWrite, FontTable,
+    FontTableReader,
 };
 
 /// Various types of tables by name
@@ -34,6 +35,19 @@ impl std::fmt::Display for NamedTable {
         match self {
             NamedTable::C2PA(_) => write!(f, "C2PA"),
             NamedTable::Generic(_) => write!(f, "Generic(DATA)"),
+        }
+    }
+}
+
+impl<'a> FontTableReader<'a> for NamedTable {
+    type Error = FontIoError;
+
+    fn get_reader(&'a self) -> Result<impl Read + Seek + 'a, Self::Error> {
+        match self {
+            NamedTable::C2PA(_table) => {
+                Err(FontIoError::InvalidC2paTableContainer)
+            }
+            NamedTable::Generic(table) => table.get_reader(),
         }
     }
 }

--- a/c2pa-font-handler/src/woff1/table/named_table.rs
+++ b/c2pa-font-handler/src/woff1/table/named_table.rs
@@ -19,7 +19,6 @@ use std::io::{Read, Seek, Write};
 use crate::{
     data::Data, error::FontIoError, sfnt::table::TableC2PA, tag::FontTag,
     FontDataChecksum, FontDataExactRead, FontDataWrite, FontTable,
-    FontTableReader,
 };
 
 /// Various types of tables by name
@@ -35,19 +34,6 @@ impl std::fmt::Display for NamedTable {
         match self {
             NamedTable::C2PA(_) => write!(f, "C2PA"),
             NamedTable::Generic(_) => write!(f, "Generic(DATA)"),
-        }
-    }
-}
-
-impl<'a> FontTableReader<'a> for NamedTable {
-    type Error = FontIoError;
-
-    fn get_reader(&'a self) -> Result<impl Read + Seek + 'a, Self::Error> {
-        match self {
-            NamedTable::C2PA(_table) => {
-                Err(FontIoError::InvalidC2paTableContainer)
-            }
-            NamedTable::Generic(table) => table.get_reader(),
         }
     }
 }

--- a/c2pa-font-handler/src/woff1/table/named_table.rs
+++ b/c2pa-font-handler/src/woff1/table/named_table.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 
 /// Various types of tables by name
+#[derive(Clone, Debug)]
 pub enum NamedTable {
     /// 'C2PA' table
     C2PA(TableC2PA),


### PR DESCRIPTION
<!--  Title should use the format: "ISSUE-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/ISSUE-123/featureName"  -->
<!--        Branch names for Bugs: "fix/ISSUE-123/bugFixName"       -->
# Issue(s)

- C2PA-688

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [X] **Merge Commit** will be updated with `(MAJOR)` | `(MINOR)` when appropriate
- [X] **PR labeled** appropriately
- [X] Changes include a single fix/feature
- [X] **Documentation** updated:
  - [X] Developer documentation (ReadMe files)
  - [X] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [X] **Test case(s)** added
  - [X] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

This adds a `TryFrom<Woff1Font> for SfntFont` conversion. The conversion does:

- Builds up the SFNT header
  - This includes recalculating the `rangeShift`, `entrySelector`, and `searchRange` values
  - Updates the number of tables to be the same count minus one for  C2PA table
- Copies all, except for the C2PA, tables to the SFNT; decompressing any tables that are compressed
- Discards private and metadata sections 

The logic behind this was to convert the WOFF container to a SFNT so we can eventually use the same rendering library to create a thumbnail. Currently, the `cosmic-text` crate doesn't appear to support reading WOFF fonts.

# Verification Instructions

<!-- Instructions for checking or testing this change. -->

The `woff` example was updated to convert the font to OTF if the `--output path/to/output.otf` is specified.