### PR TITLE
C2PA-708: Check for stubbed DSIG

### DIFF
--- a/c2pa-font-handler/examples/stub_dsig.rs
+++ b/c2pa-font-handler/examples/stub_dsig.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Monotype Imaging Inc.
+// Copyright 2024-2025 Monotype Imaging Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/c2pa-font-handler/examples/stub_dsig.rs
+++ b/c2pa-font-handler/examples/stub_dsig.rs
@@ -15,7 +15,7 @@
 //! Example of using the font-io library to stub a DSIG table in an SFNT
 //! font.
 
-use c2pa_font_handler::{FontDSIGStubber, FontDataRead, MutFontDataWrite};
+use c2pa_font_handler::sfnt::font::stub_dsig_stream;
 use clap::Parser;
 
 /// This tool can be used to take a font file and remove the DSIG table from it,
@@ -41,15 +41,10 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Open the input file
     let mut input_file = std::fs::File::open(&args.input)?;
-    // Read the font file
-    let mut font =
-        c2pa_font_handler::sfnt::font::SfntFont::from_reader(&mut input_file)?;
-    // Stub the DSIG table
-    font.stub_dsig()?;
     // Open the output file
     let mut output_file = std::fs::File::create(&args.output)?;
-    // And write the font file
-    font.write(&mut output_file)?;
+    // Perform the DSIG stubbing operation
+    stub_dsig_stream(&mut input_file, &mut output_file)?;
 
     Ok(())
 }

--- a/c2pa-font-handler/src/lib.rs
+++ b/c2pa-font-handler/src/lib.rs
@@ -207,3 +207,23 @@ pub trait FontDSIGStubber {
     /// Stub the DSIG table in the font.
     fn stub_dsig(&mut self) -> Result<(), Self::Error>;
 }
+
+/// Represents the state of the DSIG table in a font.
+pub enum DSIGType {
+    /// The DSIG table is not present in the font.
+    NotPresent,
+    /// The DSIG table is present in the font and valid.
+    Present,
+    /// The DSIG table is present in the font, but it is empty or invalid.
+    Stubbed,
+}
+
+/// A trait for detecting if a font has a DSIG table. This is useful when you
+/// want to check if a font has a DSIG table without actually reading the
+/// entire font data into memory.
+pub trait FontDSIGDetector {
+    /// The error type for detecting the DSIG table.
+    type Error;
+    /// Detects if the font has a DSIG table.
+    fn check_for_dsig(&mut self) -> Result<DSIGType, Self::Error>;
+}

--- a/c2pa-font-handler/src/sfnt/font.rs
+++ b/c2pa-font-handler/src/sfnt/font.rs
@@ -13,6 +13,39 @@
 //  limitations under the License.
 
 //! SFNT font.
+//!
+//! The crate provides an implementation of the SFNT font format, which is
+//! used by OpenType and TrueType fonts. It includes functionality for reading
+//! and writing SFNT fonts, as well as stubbing the DSIG table.
+//!
+//! # Stubbing the DSIG Table
+//!
+//! The DSIG table is used to store digital signatures for fonts. This crate
+//! provides functionality to stub the DSIG table, which is useful for
+//! keeping a DSIG if present, but zeroing out the signatures and just having
+//! a stub table. This is useful for fonts that are being modified or
+//! processed (i.e., when adding C2PA), as it allows the font to be saved
+//! without invalidating the signatures.
+//!
+//! The following is an example of how to efficiently stub the DSIG table in a
+//! stream without loading the entire font into memory:
+//!
+//! ```no_run
+//! use std::{
+//!     fs::File,
+//!     io::{BufReader, BufWriter},
+//! };
+//!
+//! use c2pa_font_handler::{error::FontIoError, sfnt::font::stub_dsig_stream};
+//! # fn main() -> Result<(), FontIoError> {
+//! let input_file = File::open("path/to/input/font.ttf")?;
+//! let output_file = File::create("path/to/output/font.ttf")?;
+//! let mut reader = BufReader::new(input_file);
+//! let mut writer = BufWriter::new(output_file);
+//! stub_dsig_stream(&mut reader, &mut writer)?;
+//! # Ok(())
+//! # }
+//! ```
 
 use std::{
     collections::{btree_map::Entry, BTreeMap},
@@ -35,9 +68,9 @@ use crate::{
     sfnt::table::TableC2PA,
     tag::FontTag,
     utils::align_to_four,
-    Font, FontDSIGStubber, FontDataChecksum, FontDataExactRead, FontDataRead,
-    FontDataWrite, FontDirectory, FontDirectoryEntry, FontHeader, FontTable,
-    MutFontDataWrite,
+    DSIGType, Font, FontDSIGDetector, FontDSIGStubber, FontDataChecksum,
+    FontDataExactRead, FontDataRead, FontDataWrite, FontDirectory,
+    FontDirectoryEntry, FontHeader, FontTable, MutFontDataWrite,
 };
 
 /// Implementation of an SFNT font.
@@ -207,6 +240,80 @@ impl FontDSIGStubber for SfntFont {
         }
         Ok(())
     }
+}
+
+impl<T: Read + Seek + ?Sized> FontDSIGDetector for T {
+    type Error = FontIoError;
+
+    fn check_for_dsig(&mut self) -> Result<crate::DSIGType, Self::Error> {
+        // Grab the original position.
+        let original_position = self.stream_position()?;
+        // We need to parse the header to be able to read the table directory.
+        let font_header = SfntHeader::from_reader(self)?;
+        // And now we can read the table directory.
+        let font_directory = SfntDirectory::from_reader_with_count(
+            self,
+            font_header.numTables as usize,
+        )?;
+        let dsig_type = match font_directory
+            .entries()
+            .iter()
+            .find(|e| e.tag == FontTag::DSIG)
+        {
+            Some(entry) => {
+                // Since DSIG table, according to the spec, must be at the end
+                // of the file we can use the offset to
+                // determine where the end of the font data is.
+                let original_dsig_offset = entry.offset();
+                let dsig_table = TableDSIG::from_reader_exact(
+                    self,
+                    original_dsig_offset as u64,
+                    entry.length() as usize,
+                )?;
+                if dsig_table.is_stubbed() {
+                    tracing::debug!("DSIG table is stubbed.");
+                    DSIGType::Stubbed
+                } else {
+                    tracing::debug!("DSIG table is present and not stubbed.");
+                    // If it is not stubbed, we can return that it is present.
+                    DSIGType::Present
+                }
+            }
+            None => {
+                tracing::debug!("DSIG table is not present.");
+                DSIGType::NotPresent
+            }
+        };
+        self.seek(std::io::SeekFrom::Start(original_position))?;
+        Ok(dsig_type)
+    }
+}
+
+/// A convenience function to stub the DSIG table in a stream. This will
+/// read the stream, check for the DSIG table, and if it is present, stub
+/// it. If the DSIG table is not present or already stubbed, it will simply
+/// copy the stream to the writer without modification.
+pub fn stub_dsig_stream<R: Read + Seek + ?Sized, W: std::io::Write + ?Sized>(
+    reader: &mut R,
+    writer: &mut W,
+) -> Result<(), FontIoError> {
+    match reader.check_for_dsig()? {
+        DSIGType::NotPresent | DSIGType::Stubbed => {
+            tracing::debug!(
+                "DSIG table is not present or already stubbed, copying stream."
+            );
+            std::io::copy(reader, writer)?;
+        }
+        DSIGType::Present => {
+            tracing::debug!(
+                "DSIG table is present and not stubbed, proceeding to stub it."
+            );
+            let mut sfnt_font = SfntFont::from_reader(reader)?;
+            sfnt_font.stub_dsig()?;
+            sfnt_font.write(writer)?;
+        }
+    };
+    Ok(())
 }
 
 impl C2PASupport for SfntFont {

--- a/c2pa-font-handler/src/sfnt/font_test.rs
+++ b/c2pa-font-handler/src/sfnt/font_test.rs
@@ -276,7 +276,7 @@ fn test_font_stub_dsig_stream_present() {
     let dsig_table = NamedTable::DSIG(TableDSIG {
         version: 1,
         numSignatures: 1,
-        flags: TableDSIG::DO_NOT_RESIGN,
+        flags: 1,
         data: vec![0x01, 0x02, 0x03, 0x04],
     });
     font.tables.insert(FontTag::DSIG, dsig_table);

--- a/c2pa-font-handler/src/sfnt/font_test.rs
+++ b/c2pa-font-handler/src/sfnt/font_test.rs
@@ -14,6 +14,8 @@
 
 //! Tests for SFNT font.
 
+use std::io::Cursor;
+
 use super::*;
 use crate::{
     c2pa::{ContentCredentialRecord, UpdateContentCredentialRecord},
@@ -25,7 +27,7 @@ use crate::{
 #[test]
 fn test_load_of_font() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let font = SfntFont::from_reader(&mut reader).unwrap();
     //assert_eq!(font.header.version(), 0x00010000);
     assert_eq!(font.header.num_tables(), 11);
@@ -39,7 +41,7 @@ fn test_write_font_data_with_zero_tables() {
         directory: SfntDirectory::new(),
         tables: std::collections::BTreeMap::new(),
     };
-    let mut writer = std::io::Cursor::new(Vec::new());
+    let mut writer = Cursor::new(Vec::new());
     let result = font.write(&mut writer);
     assert!(result.is_err());
     let err = result.err().unwrap();
@@ -58,7 +60,7 @@ fn test_load_font_with_bad_magic() {
     bad_font_data[1] = 0xff;
     bad_font_data[2] = 0xff;
     bad_font_data[3] = 0xff;
-    let mut reader = std::io::Cursor::new(&bad_font_data);
+    let mut reader = Cursor::new(&bad_font_data);
     let result = SfntHeader::from_reader(&mut reader);
     assert!(result.is_err());
     let err = result.err().unwrap();
@@ -77,7 +79,7 @@ fn test_load_font_with_wrong_number_of_directory_entries() {
     // Add a bad number of directory entries
     bad_font_data[4] = 0x00;
     bad_font_data[5] = 0x01;
-    let mut reader = std::io::Cursor::new(&bad_font_data);
+    let mut reader = Cursor::new(&bad_font_data);
     let result = SfntFont::from_reader(&mut reader);
     assert!(result.is_err());
     let err = result.err().unwrap();
@@ -88,9 +90,9 @@ fn test_load_font_with_wrong_number_of_directory_entries() {
 #[test]
 fn test_font_write() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
-    let mut writer = std::io::Cursor::new(Vec::new());
+    let mut writer = Cursor::new(Vec::new());
 
     // Write the font to the writer
     font.write(&mut writer).unwrap();
@@ -106,9 +108,9 @@ fn test_font_write() {
 #[test]
 fn test_font_write_new_table_added() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
-    let mut writer = std::io::Cursor::new(Vec::new());
+    let mut writer = Cursor::new(Vec::new());
 
     // Add a new table to the font
     let new_table = Data {
@@ -137,9 +139,9 @@ fn test_font_write_new_table_added() {
 #[test]
 fn test_write_font_without_c2pa() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
-    let mut writer = std::io::Cursor::new(Vec::new());
+    let mut writer = Cursor::new(Vec::new());
     let result = font.write(&mut writer);
     assert!(result.is_ok());
     // Verify what is in writer
@@ -151,7 +153,7 @@ fn test_write_font_without_c2pa() {
 #[test]
 fn test_write_font_with_c2pa() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let record = ContentCredentialRecord::builder()
         .with_version(0, 1)
@@ -161,12 +163,12 @@ fn test_write_font_with_c2pa() {
         .unwrap();
     assert!(!font.has_c2pa());
     font.add_c2pa_record(record).unwrap();
-    let mut writer = std::io::Cursor::new(Vec::new());
+    let mut writer = Cursor::new(Vec::new());
     let result = font.write(&mut writer);
     assert!(result.is_ok());
     // Verify what is in writer
     let written_data = writer.into_inner();
-    let mut new_reader = std::io::Cursor::new(&written_data);
+    let mut new_reader = Cursor::new(&written_data);
     let new_font = SfntFont::from_reader(&mut new_reader).unwrap();
     assert!(new_font.has_c2pa());
     assert_eq!(new_font.tables.len(), font.tables.len());
@@ -175,9 +177,9 @@ fn test_write_font_with_c2pa() {
 #[test]
 fn test_font_write_table_deleted() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
-    let mut writer = std::io::Cursor::new(Vec::new());
+    let mut writer = Cursor::new(Vec::new());
 
     // Remove a table from the font
     font.tables.remove(&FontTag::DSIG);
@@ -197,7 +199,7 @@ fn test_font_write_table_deleted() {
 #[test]
 fn test_font_stub_dsig() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
 
     // Stub the DSIG table
@@ -210,9 +212,98 @@ fn test_font_stub_dsig() {
 }
 
 #[test]
+#[tracing_test::traced_test]
+fn test_font_stub_dsig_stream_not_present() {
+    let font_data = vec![
+        0x00, 0x01, 0x00, 0x00, // sfntVersion
+        0x00, 0x01, // numTables
+        0x00, 0x00, // searchRange
+        0x00, 0x00, // entrySelector
+        0x00, 0x00, // rangeShift
+        // One table directory entry for a non-DSIG table
+        0x74, 0x65, 0x73, 0x74, // tag 'test'
+        0x00, 0x00, 0x00, 0x40, // offset
+        0x00, 0x00, 0x00, 0x04, // comp length
+        0x00, 0x00, 0x00, 0x04, // orig length
+    ];
+    let mut reader = Cursor::new(font_data);
+    let mut destination = Cursor::new(Vec::new());
+
+    // Attempt to stub the DSIG table when it is not present
+    let result = stub_dsig_stream(&mut reader, &mut destination);
+    assert!(result.is_ok());
+    assert!(logs_contain("DSIG table is not present."));
+    assert!(logs_contain(
+        "DSIG table is not present or already stubbed, copying stream."
+    ));
+
+    // Rewind the destination to read it back
+    destination.set_position(0);
+    let font = SfntFont::from_reader(&mut destination).unwrap();
+    let dsig = font.tables.get(&FontTag::DSIG);
+    assert!(dsig.is_none());
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn test_font_stub_dsig_stream_stubbed() {
+    let font_data = include_bytes!("../../../.devtools/font.otf");
+    let mut reader = Cursor::new(font_data);
+    let mut destination = Cursor::new(Vec::new());
+
+    // Stub the DSIG table
+    let result = stub_dsig_stream(&mut reader, &mut destination);
+    assert!(result.is_ok());
+
+    // Rewind the destination to read it back
+    destination.set_position(0);
+    let font = SfntFont::from_reader(&mut destination).unwrap();
+    // Verify the DSIG table is now a stub
+    let dsig = font.tables.get(&FontTag::DSIG).unwrap();
+    assert!(matches!(dsig, NamedTable::DSIG(_)));
+    assert!(logs_contain("DSIG table is stubbed."));
+    assert!(logs_contain(
+        "DSIG table is not present or already stubbed, copying stream."
+    ));
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn test_font_stub_dsig_stream_present() {
+    let font_data = include_bytes!("../../../.devtools/font.otf");
+    let mut reader = Cursor::new(font_data);
+    let mut font = SfntFont::from_reader(&mut reader).unwrap();
+    let dsig_table = NamedTable::DSIG(TableDSIG {
+        version: 1,
+        numSignatures: 1,
+        flags: TableDSIG::DO_NOT_RESIGN,
+        data: vec![0x01, 0x02, 0x03, 0x04],
+    });
+    font.tables.insert(FontTag::DSIG, dsig_table);
+    let mut reader = Cursor::new(Vec::new());
+    font.write(&mut reader).unwrap();
+    reader.set_position(0);
+    let mut destination = Cursor::new(Vec::new());
+
+    // Stub the DSIG table
+    let result = stub_dsig_stream(&mut reader, &mut destination);
+    assert!(result.is_ok());
+
+    destination.set_position(0);
+    let font = SfntFont::from_reader(&mut destination).unwrap();
+    // Verify the DSIG table is now a stub
+    let dsig = font.tables.get(&FontTag::DSIG).unwrap();
+    assert!(matches!(dsig, NamedTable::DSIG(_)));
+    assert!(logs_contain("DSIG table is present and not stubbed."));
+    assert!(logs_contain(
+        "DSIG table is present and not stubbed, proceeding to stub it."
+    ));
+}
+
+#[test]
 fn test_font_as_font_trait() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let font = SfntFont::from_reader(&mut reader).unwrap();
     assert_eq!(font.header().sfntVersion as u32, 0x4f54544f);
     assert_eq!(11, font.header().num_tables());
@@ -227,7 +318,7 @@ fn test_font_as_font_trait() {
 #[test]
 fn test_adding_c2pa_record() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let record = ContentCredentialRecord::builder()
         .with_version(0, 1)
@@ -253,7 +344,7 @@ fn test_adding_c2pa_record() {
 #[test]
 fn test_adding_c2pa_record_when_one_exists() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let record = ContentCredentialRecord::builder()
         .with_version(0, 1)
@@ -273,7 +364,7 @@ fn test_adding_c2pa_record_when_one_exists() {
 #[test]
 fn test_removing_c2pa_record() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let record = ContentCredentialRecord::builder()
         .with_version(0, 1)
@@ -295,7 +386,7 @@ fn test_removing_c2pa_record() {
 #[test]
 fn test_removing_c2pa_record_when_one_does_not_exists() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let result = font.remove_c2pa_record();
     assert!(result.is_err());
@@ -306,7 +397,7 @@ fn test_removing_c2pa_record_when_one_does_not_exists() {
 #[test]
 fn test_updating_c2pa_record_when_occupied() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let record = ContentCredentialRecord::builder()
         .with_version(0, 1)
@@ -335,7 +426,7 @@ fn test_updating_c2pa_record_when_occupied() {
 #[test]
 fn test_updating_c2pa_record_when_vacant() {
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     let update_record = UpdateContentCredentialRecord::builder()
         .without_active_manifest_uri()
@@ -354,7 +445,7 @@ fn test_updating_c2pa_record_when_vacant() {
 
 #[test]
 fn test_sfnt_font_chunk_reader_bad_header() {
-    let mut reader = std::io::Cursor::new(vec![0u8; 10]);
+    let mut reader = Cursor::new(vec![0u8; 10]);
     let result = SfntFont::get_chunk_positions(&mut reader);
     assert!(result.is_err());
     let err = result.err().unwrap();
@@ -366,7 +457,7 @@ fn test_sfnt_font_chunk_reader_bad_header() {
 #[test]
 fn test_sfnt_font_chunk_reader_bad_directory() {
     // Mimic a bad font in memory, where the directory is too short
-    let mut reader = std::io::Cursor::new(vec![
+    let mut reader = Cursor::new(vec![
         // Simulate the magic number
         0x00, 0x01, 0x00, 0x00, // sfntVersion
         0x00, 0x01, // numTables
@@ -387,7 +478,7 @@ fn test_sfnt_font_chunk_reader_bad_directory() {
 #[test]
 fn test_sfnt_font_chunk_reader_valid() {
     let font_bytes = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_bytes);
+    let mut reader = Cursor::new(font_bytes);
     let result = SfntFont::get_chunk_positions(&mut reader);
     assert!(result.is_ok());
     let mut positions = result.unwrap();
@@ -420,7 +511,7 @@ fn test_sfnt_font_chunk_reader_valid() {
 fn test_sfnt_font_chunk_reader_with_c2pa() {
     // Load the font data bytes
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     // Read in the font, so we can add a C2PA record
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     // Build up the C2PA record
@@ -433,13 +524,13 @@ fn test_sfnt_font_chunk_reader_with_c2pa() {
     // Add it to the font stream
     font.add_c2pa_record(record).unwrap();
     // Write the font out to a new writer
-    let mut writer = std::io::Cursor::new(Vec::new());
+    let mut writer = Cursor::new(Vec::new());
     let result = font.write(&mut writer);
     assert!(result.is_ok());
     // Get access to the written data
     let written_data = writer.into_inner();
     // And use it in a reader to read chunk positions
-    let mut new_reader = std::io::Cursor::new(&written_data);
+    let mut new_reader = Cursor::new(&written_data);
     let result = SfntFont::get_chunk_positions(&mut new_reader);
     assert!(result.is_ok());
     let positions = result.unwrap();
@@ -455,7 +546,7 @@ fn test_sfnt_font_chunk_reader_with_c2pa() {
 fn test_sfnt_font_chunk_reader_tracing() {
     // Load the font data bytes
     let font_data = include_bytes!("../../../.devtools/font.otf");
-    let mut reader = std::io::Cursor::new(font_data);
+    let mut reader = Cursor::new(font_data);
     // Read in the font, so we can add a C2PA record
     let mut font = SfntFont::from_reader(&mut reader).unwrap();
     // Build up the C2PA record
@@ -468,13 +559,13 @@ fn test_sfnt_font_chunk_reader_tracing() {
     // Add it to the font stream
     font.add_c2pa_record(record).unwrap();
     // Write the font out to a new writer
-    let mut writer = std::io::Cursor::new(Vec::new());
+    let mut writer = Cursor::new(Vec::new());
     let result = font.write(&mut writer);
     assert!(result.is_ok());
     // Get access to the written data
     let written_data = writer.into_inner();
     // And use it in a reader to read chunk positions
-    let mut new_reader = std::io::Cursor::new(&written_data);
+    let mut new_reader = Cursor::new(&written_data);
     let _ = SfntFont::get_chunk_positions(&mut new_reader);
     assert!(logs_contain("HeaderDirectory position information added"));
     assert!(logs_contain(
@@ -525,8 +616,7 @@ fn test_try_from_woff_to_sfnt() {
         0x77, 0x55, 0x33, 0x58, // Metadata
     ];
     let woff_font =
-        Woff1Font::from_reader(&mut std::io::Cursor::new(woff_data.clone()))
-            .unwrap();
+        Woff1Font::from_reader(&mut Cursor::new(woff_data.clone())).unwrap();
     let sfnt_font_result: Result<SfntFont, _> = woff_font.try_into();
     assert!(sfnt_font_result.is_ok());
     let sfnt_font = sfnt_font_result.unwrap();
@@ -587,8 +677,7 @@ fn test_try_from_woff_to_sfnt_with_c2pa() {
     ];
 
     let woff_font =
-        Woff1Font::from_reader(&mut std::io::Cursor::new(woff_data.clone()))
-            .unwrap();
+        Woff1Font::from_reader(&mut Cursor::new(woff_data.clone())).unwrap();
     let sfnt_font_result: Result<SfntFont, _> = woff_font.try_into();
     assert!(sfnt_font_result.is_ok());
     let sfnt_font = sfnt_font_result.unwrap();
@@ -643,8 +732,7 @@ fn test_try_from_woff_to_sfnt_with_compression() {
     ];
 
     let woff_font =
-        Woff1Font::from_reader(&mut std::io::Cursor::new(woff_data.clone()))
-            .unwrap();
+        Woff1Font::from_reader(&mut Cursor::new(woff_data.clone())).unwrap();
     let sfnt_font_result: Result<SfntFont, _> = woff_font.try_into();
     assert!(sfnt_font_result.is_ok());
     let sfnt_font = sfnt_font_result.unwrap();
@@ -689,8 +777,7 @@ fn test_try_from_woff_to_sfnt_with_no_tables() {
     ];
 
     let woff_font =
-        Woff1Font::from_reader(&mut std::io::Cursor::new(woff_data.clone()))
-            .unwrap();
+        Woff1Font::from_reader(&mut Cursor::new(woff_data.clone())).unwrap();
     let sfnt_font_result: Result<SfntFont, _> = woff_font.try_into();
     assert!(sfnt_font_result.is_err());
     assert!(matches!(sfnt_font_result, Err(FontIoError::NoTablesFound)));

--- a/c2pa-font-handler/src/sfnt/table/dsig.rs
+++ b/c2pa-font-handler/src/sfnt/table/dsig.rs
@@ -58,6 +58,14 @@ impl TableDSIG {
             data: Vec::new(),
         }
     }
+
+    /// Check if this DSIG table is a stub.
+    pub(crate) fn is_stubbed(&self) -> bool {
+        self.version == Self::DEFAULT_VERSION
+            && self.numSignatures == 0
+            && self.flags == Self::DO_NOT_RESIGN
+            && self.data.is_empty()
+    }
 }
 
 impl FontDataExactRead for TableDSIG {

--- a/c2pa-font-handler/src/sfnt/table/dsig_test.rs
+++ b/c2pa-font-handler/src/sfnt/table/dsig_test.rs
@@ -141,3 +141,42 @@ fn test_table_dsig_length() {
     };
     assert_eq!(dsig.len(), 8);
 }
+
+#[test]
+fn test_table_dsig_is_stubbed() {
+    // Verify the "stub()" is actually stubbed
+    let dsig = TableDSIG::stub();
+    assert!(dsig.is_stubbed());
+    assert_eq!(dsig.version, 1);
+    assert_eq!(dsig.numSignatures, 0);
+    assert_eq!(dsig.flags, 1);
+    assert!(dsig.data.is_empty());
+
+    // Now look like a stub, but with a different version
+    let dsig = TableDSIG {
+        version: 10,
+        ..TableDSIG::stub()
+    };
+    assert!(!dsig.is_stubbed());
+
+    // Now look like a stub, but with a different numSignatures
+    let dsig = TableDSIG {
+        numSignatures: 10,
+        ..TableDSIG::stub()
+    };
+    assert!(!dsig.is_stubbed());
+
+    // Now look like a stub, but with a different flags
+    let dsig = TableDSIG {
+        flags: 10,
+        ..TableDSIG::stub()
+    };
+    assert!(!dsig.is_stubbed());
+
+    // Now look like a stub, but with data
+    let dsig = TableDSIG {
+        data: vec![1, 2, 3],
+        ..TableDSIG::stub()
+    };
+    assert!(!dsig.is_stubbed());
+}


### PR DESCRIPTION
<!--  Title should use the format: "ISSUE-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/ISSUE-123/featureName"  -->
<!--        Branch names for Bugs: "fix/ISSUE-123/bugFixName"       -->
# Issue(s)

- C2PA-708

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [X] **Merge Commit** will be updated with `(MAJOR)` | `(MINOR)` when appropriate
- [X] **PR labeled** appropriately
- [X] Changes include a single fix/feature
- [X] **Documentation** updated:
  - [X] Developer documentation (ReadMe files)
  - [X] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [X] **Test case(s)** added
  - [X] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->
This adds the ability to stub DSIG in a streaming manner, to reduce memory usage mostly and there is a slight performance boost when no DSIG is in the font to begin with.


# Verification Instructions
<!-- Instructions for checking or testing this change. -->

The `stub_dsig` example works with the new code, use it with the different use cases.