### PR TITLE
release: MSRV => 1.87, better check for DSIG, thumbnail rendering for SFNT, and more WOFF1 support

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -18,6 +18,7 @@
     "CHANGELOG.md"
   ],
   "words": [
+    "automock",
     "byteorder",
     "cdef",
     "cksum",
@@ -27,21 +28,29 @@
     "DSIG",
     "flamegraph",
     "flate",
+    "fontdb",
     "fullword",
     "FWORD",
     "gitflow",
     "halfword",
     "halfwords",
     "ilog",
+    "luma",
+    "mockall",
+    "Pixmap",
     "ppem",
     "repr",
     "reqs",
+    "resvg",
     "rustup",
+    "rustybuzz",
     "sfnt",
     "Stubber",
     "taskset",
     "thiserror",
     "toolset",
-    "xdadau"
+    "usvg",
+    "xdadau",
+    "xywh"
   ]
 }

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         # PRs should check the default toolchain, stable, and nightly
-        rust_version: [1.75.0, stable, nightly]
+        rust_version: [1.82.0, stable, nightly]
     uses: ./.github/workflows/.builds.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         # PRs should check the default toolchain, stable, and nightly
-        rust_version: [1.82.0, stable, nightly]
+        rust_version: [1.87.0, stable, nightly]
     uses: ./.github/workflows/.builds.yml
     with:
       os: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,19 +73,32 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
@@ -95,9 +108,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -109,10 +122,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.6.0"
+name = "base64"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
@@ -121,16 +146,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "bytes"
-version = "1.9.0"
+name = "byteorder-lite"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "c2pa-font-handler"
@@ -140,16 +191,24 @@ dependencies = [
  "byteorder",
  "bytes",
  "clap",
+ "cosmic-text",
  "criterion",
  "dhat",
  "flate2",
+ "image",
+ "mockall",
+ "regex",
+ "resvg",
  "serde",
  "serde_json",
+ "svg",
  "thiserror",
+ "tiny-skia",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "unicode-script",
 ]
 
 [[package]]
@@ -160,9 +219,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]
@@ -202,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -212,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -224,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -250,10 +309,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "cosmic-text"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da46a9d5a8905cc538a4a5bceb6a4510de7a51049c5588c0114efce102bcbbe8"
+dependencies = [
+ "bitflags 2.9.1",
+ "fontdb 0.16.2",
+ "log",
+ "rangemap",
+ "rustc-hash",
+ "rustybuzz 0.14.1",
+ "self_cell",
+ "smol_str",
+ "swash",
+ "sys-locale",
+ "ttf-parser 0.21.1",
+ "unicode-bidi",
+ "unicode-linebreak",
+ "unicode-script",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "crc32fast"
@@ -266,25 +363,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -297,7 +391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -332,6 +426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "data-url"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
+
+[[package]]
 name = "dhat"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,20 +448,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "flate2"
-version = "1.1.0"
+name = "fdeflate"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "font-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.25.1",
+]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "gif"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -387,21 +570,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.1"
+name = "image"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "num-traits",
+ "png",
+]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
+name = "image-webp"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "b77d01e822461baa8409e156015a1d91735549f0f2c17691bd2d996bef238f7f"
 dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
+ "byteorder-lite",
+ "quick-error",
 ]
+
+[[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -419,10 +613,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.14"
+name = "itertools"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -435,6 +638,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1077d333efea6170d9ccb96d3c3026f300ca0773da4938cc4c811daa6df68b0c"
+dependencies = [
+ "arrayvec",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,9 +655,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libz-ng-sys"
@@ -458,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -468,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchers"
@@ -488,12 +707,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.5"
+name = "memmap2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -504,13 +733,39 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -534,18 +789,24 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "oorandom"
@@ -561,9 +822,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -571,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -583,10 +844,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.15"
+name = "pico-args"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "plotters"
@@ -617,6 +884,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,13 +932,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.37"
+name = "quick-error"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "rayon"
@@ -655,12 +973,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.7"
+name = "read-fonts"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "6f96bfbb7df43d34a2b7b8582fcbcb676ba02a763265cb90bc8aabfd62b57d64"
 dependencies = [
- "bitflags",
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -708,6 +1036,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,15 +1081,50 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytemuck",
+ "libm",
+ "smallvec",
+ "ttf-parser 0.21.1",
+ "unicode-bidi-mirroring 0.2.0",
+ "unicode-ccc 0.2.0",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser 0.25.1",
+ "unicode-bidi-mirroring 0.4.0",
+ "unicode-ccc 0.4.0",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -747,19 +1142,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serde"
-version = "1.0.218"
+name = "self_cell"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -768,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -795,27 +1196,82 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.13.2"
+name = "simd-adler32"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "skrifa"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbeb4ca4399663735553a09dd17ce7e49a0a0203f03b706b39628c4d913a8607"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
 ]
 
 [[package]]
@@ -825,10 +1281,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "syn"
-version = "2.0.90"
+name = "svg"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "94afda9cd163c04f6bee8b4bf2501c91548deae308373c436f36aeff3cf3c4a3"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
+
+[[package]]
+name = "swash"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f745de914febc7c9ab4388dfaf94bbc87e69f57bb41133a9b0c84d4be49856f3"
+dependencies = [
+ "skrifa",
+ "yazi",
+ "zeno",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -836,19 +1319,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.6"
+name = "sys-locale"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -872,6 +1370,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,10 +1406,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.44.2"
+name = "tinyvec"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1006,10 +1545,118 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.14"
+name = "ttf-parser"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb 0.23.0",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz 0.20.1",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
 
 [[package]]
 name = "utf8parse"
@@ -1019,9 +1666,15 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1108,6 +1761,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,7 +1788,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1219,3 +1878,36 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "yazi"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
+
+[[package]]
+name = "zeno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99a5bab8d7dedf81405c4bb1f2b83ea057643d9cb28778cea9eecddeedd2e028"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,16 +30,24 @@ description = "C2PA Font Handler (or codec) to be used with the c2pa-rs SDK."
 anyhow = { version = "1.0.94" }
 byteorder = { version = "1.5.0" }
 bytes = { version = "1.9.0" }
-criterion = { version = "0.5.1", features = ["html_reports"]}
+cosmic-text = { version = "0.14.2" }
 clap = { version = "4.5.23", features = ["derive"] }
+criterion = { version = "0.6.0", features = ["html_reports"]}
 flate2 = { version = "1.1.0", features = ["zlib-ng"], default-features = false }
+image = { version = "0.25.6", default-features = false }
+mockall = { version = "0.13.1" }
+regex = { version = "1.11.1" }
+resvg = { version = "0.45.1" }
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = { version = "1.0.139" }
+svg = { version = "0.18.0" }
 thiserror = { version = "2.0.6" }
+tiny-skia = { version = "0.11.4", default-features = false }
 tokio = { version = "1.42.0", features = ["full"] }
 tracing = { version = "0.1.41" }
 tracing-subscriber = { version = "0.3.19", features = ["json", "env-filter"] }
 tracing-test = { version = "0.2.5" }
+unicode-script = { version = "0.5.7" }
 
 [workspace.lints.rust]
 missing_docs = "deny"

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,7 +1,6 @@
 # C2PA Font Handler
 
 - [Foreword](#foreword)
-- [Features](#features)
 - [License](#license)
 - [Contributing](#contributing)
 
@@ -12,9 +11,7 @@ The [C2PA Font Handler/Codec library](./c2pa-font-handler/ReadMe.md) is intended
 a full-featured font software reader/writer. It is intended to do the minimum
 for handling the Content Credential for font software.
 
-## Features
-
-Currently OpenType/TrueType font software is supported by default. Support for WOFF is still in progress and can be tested out by enabling the `woff` feature.
+Currently, only OpenType/TrueType font software is supported. WOFF can be experimented with by using a feature, check out the [c2pa-font-handler Readme.md](./c2pa-font-handler/ReadMe.md).
 
 ## License
 

--- a/c2pa-font-handler/Cargo.toml
+++ b/c2pa-font-handler/Cargo.toml
@@ -24,25 +24,36 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
-default = []
-flate = ["dep:flate2"]
+default = ["svg-thumbnails"]
 compression = ["flate"]
+flate = ["dep:flate2"]
+png-thumbnails = ["thumbnails", "dep:tiny-skia", "tiny-skia/png", "tiny-skia/png-format", "dep:image", "image/png"]
+svg-thumbnails = ["thumbnails", "dep:svg", "dep:resvg"]
+thumbnails = ["dep:cosmic-text", "dep:unicode-script"]
 woff = [ "compression" ]
 
 [dependencies]
 anyhow.workspace = true
 byteorder.workspace = true
 bytes.workspace = true
+cosmic-text = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
+image = { workspace = true, optional = true }
+resvg = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
+svg = { workspace = true, optional = true}
 thiserror.workspace = true
+tiny-skia = { workspace = true, optional = true }
 tracing.workspace = true
+unicode-script = { workspace = true, optional = true }
 
 [dev-dependencies]
 clap.workspace = true
 criterion.workspace = true
 dhat = {version = "0.3.3" }
+mockall.workspace = true
+regex.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
 tracing-test.workspace = true
@@ -54,8 +65,17 @@ workspace = true
 name = "woff1"
 required-features = ["woff"]
 
+[[example]]
+name = "render_thumbnail"
+required-features = ["svg-thumbnails", "png-thumbnails"]
+
 [[bench]]
 name = "sfnt"
+harness = false
+
+[[bench]]
+name = "thumbnails"
+required-features = ["svg-thumbnails", "png-thumbnails"]
 harness = false
 
 [[bench]]

--- a/c2pa-font-handler/ReadMe.md
+++ b/c2pa-font-handler/ReadMe.md
@@ -2,10 +2,13 @@
 
 - [Features](#features)
 - [Examples](#examples)
+  - [`render_thumbnails`](#render_thumbnails)
+  - [`stub_dsig`](#stub_dsig)
+  - [`woff1`](#woff1)
 
 This crate was brought in and adapted from the implementation found in [font_io.rs](https://github.com/Monotype/c2pa-rs/blob/monotype/fontSupport/sdk/src/asset_handlers/font_io.rs) and [sfnt_io.rs](https://github.com/Monotype/c2pa-rs/blob/monotype/fontSupport/sdk/src/asset_handlers/sfnt_io.rs) in the Monotype fork of the `c2pa-rs` repository.
 
-The use of "font I/O" is a bit strong, as it doesn't really do much at the moment. It has the ability read in a font and write it back out ensuring no new tables were added/removed. And with the use of the `FontDSIGStubber` trait, the font can be updated to have a stub or fake DSIG table.
+The use of "font I/O" is a bit strong, as it doesn't really do much at the moment. It has the ability read in a font and write it back out ensuring no new tables were added/removed.
 
 For more information, check out [lib.rs](./src/lib.rs).
 
@@ -15,14 +18,35 @@ There are a few features available for this crate:
 
 Feature|Note|On by Default
 -|-|-
-`flate`|Compiles the `flate2` crate|No
-`compression`|Turns on support for compression, using the `flate` feature|No
-`woff`|Turns on support for WOFF fonts (this is currently a work in progress)|No
+`compression`|Turns on support for compression, using the `flate` feature|❌ No
+`flate`|Compiles the `flate2` crate|❌ No
+`png-thumbnails`|Adds the ability to create PNG thumbnails for SFNT files|❌ No
+`svg-thumbnails`|Adds the ability to create SVG thumbnails for SFNT files|✅ Yes
+`thumbnails`|Use of `cosmic-text` crate for generating thumbnails; `png-thumbnails` and/or `svg-thumbnails` turn this on when used.|✅ Yes
+`woff`|Turns on support for WOFF fonts (this is currently a work in progress)|❌ No
 
 ## Examples
 
-The [stub_dsig](./examples/stub_dsig.rs) example is provided to show how to read a font, create a stub DSIG table in place of a pre-existing one. To try it out:
+### `render_thumbnails`
+
+The [render_thumbnails](./examples/render_thumbnail.rs) example is provided to show how to generate either an SVG or a PNG thumbnail for a font (currently only SFNT files supported). To run the example:
 
 ```shell
-cargo run --example stub_dsig -- --input path/to/font.ttf --output path/to/new/font.ttf
+cargo run --features="svg-thumbnails png-thumbnails" --example "render_thumbnail" -- -t svg --input "path/to/font.otf" --output "path/to/thumbnail.svg"
+```
+
+### `stub_dsig`
+
+The [stub_dsig](./examples/stub_dsig.rs) example is provided to show how to read a font, create a stub DSIG table in place of a pre-existing one. To run the example:
+
+```shell
+cargo run --example "stub_dsig" -- --input "path/to/font.otf" --output "path/to/new/font.otf"
+```
+
+### `woff1`
+
+The [woff1](./examples/woff1.rs) example is provided to show how to read a WOFF1 file. To run the example:
+
+```shell
+cargo run --features="woff" --example "woff1" -- --input "path/to/font.otf"
 ```

--- a/c2pa-font-handler/benches/thumbnails.rs
+++ b/c2pa-font-handler/benches/thumbnails.rs
@@ -1,0 +1,70 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#![allow(missing_docs)]
+//! Benchmarks for thumbnail generation and handling in C2PA fonts.
+
+#[path = "utils/profiler.rs"]
+mod profiler_utils;
+use std::io::Cursor;
+
+use c2pa_font_handler::thumbnail::{
+    CosmicTextThumbnailGenerator, PngThumbnailRenderer,
+    PngThumbnailRendererConfig, SvgThumbnailRenderer,
+    SvgThumbnailRendererConfig, ThumbnailGenerator,
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use profiler_utils::DhatProfiler;
+
+/// Collection of benchmarks for SFNT font thumbnail generation.
+fn sfnt_thumbnail_benchmarks(c: &mut Criterion) {
+    let font_data = include_bytes!("../../.devtools/font.otf");
+
+    // Benchmark for generating an SVG thumbnail
+    c.bench_function("sfnt_svg_thumbnail_default", |b| {
+        b.iter(|| {
+            let mut font_stream = Cursor::new(font_data);
+            // SVG renderer
+            let svg_renderer = Box::new(SvgThumbnailRenderer::new(
+                SvgThumbnailRendererConfig::default(),
+            ));
+            let generator = CosmicTextThumbnailGenerator::new(svg_renderer);
+            let _ = generator
+                .create_thumbnail_from_stream(&mut font_stream)
+                .unwrap();
+        });
+    });
+
+    // Benchmark for generating a PNG thumbnail
+    c.bench_function("sfnt_png_thumbnail_default", |b| {
+        b.iter(|| {
+            let mut font_stream = Cursor::new(font_data);
+            // PNG renderer
+            let png_renderer = Box::new(PngThumbnailRenderer::new(
+                PngThumbnailRendererConfig::default(),
+            ));
+            let generator = CosmicTextThumbnailGenerator::new(png_renderer);
+            let _ = generator
+                .create_thumbnail_from_stream(&mut font_stream)
+                .unwrap();
+        });
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().with_profiler(DhatProfiler::new());
+    targets =  sfnt_thumbnail_benchmarks,
+);
+criterion_main!(benches);

--- a/c2pa-font-handler/examples/render_thumbnail.rs
+++ b/c2pa-font-handler/examples/render_thumbnail.rs
@@ -1,0 +1,81 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Example of generating a thumbnail for a font.
+
+use c2pa_font_handler::thumbnail::{
+    CosmicTextThumbnailGenerator, PngThumbnailRenderer, SvgThumbnailRenderer,
+    ThumbnailGenerator,
+};
+use clap::{Parser, ValueEnum};
+
+/// Types of thumbnails that can be generated.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+enum ThumbnailType {
+    /// A thumbnail in SVG format
+    Svg,
+    /// A thumbnail in PNG format
+    Png,
+}
+
+/// An example of reading a WOFF file and writing information about it to the
+/// console.
+#[derive(Debug, Parser)]
+struct Args {
+    /// Input font file
+    #[clap(short, long)]
+    input: String,
+    /// The output file path for saving the SVG thumbnail
+    #[clap(short, long)]
+    output: String,
+    /// The type of thumbnail to generate
+    #[clap(short, long, default_value = "svg")]
+    thumbnail_type: ThumbnailType,
+}
+
+/// Main function for the render_thumbnail example.
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Initialize the logger, can be controlled with RUST_LOG=debug,info,trace,
+    // etc.
+    tracing_subscriber::fmt::init();
+    // Parse the command line arguments
+    let args = Args::parse();
+
+    let font_path = std::path::Path::new(&args.input);
+
+    let generator: Box<dyn ThumbnailGenerator> = match args.thumbnail_type {
+        ThumbnailType::Svg => {
+            let renderer = Box::new(SvgThumbnailRenderer::default());
+            Box::new(CosmicTextThumbnailGenerator::new(renderer))
+        }
+        ThumbnailType::Png => {
+            let renderer = Box::new(PngThumbnailRenderer::default());
+            Box::new(CosmicTextThumbnailGenerator::new(renderer))
+        }
+    };
+    let thumbnail = generator
+        .create_thumbnail(font_path)
+        .map_err(|e| anyhow::anyhow!("Failed to create thumbnail: {}", e))?;
+    println!(
+        "Thumbnail created with mime type: {}",
+        thumbnail.mime_type()
+    );
+    // Write the thumbnail to a file
+    std::fs::write(&args.output, thumbnail.data()).map_err(|e| {
+        anyhow::anyhow!("Failed to write thumbnail to file: {}", e)
+    })?;
+    println!("Thumbnail written to: {}", args.output);
+    Ok(())
+}

--- a/c2pa-font-handler/examples/stub_dsig.rs
+++ b/c2pa-font-handler/examples/stub_dsig.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Monotype Imaging Inc.
+// Copyright 2024-2025 Monotype Imaging Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 //! Example of using the font-io library to stub a DSIG table in an SFNT
 //! font.
 
-use c2pa_font_handler::{FontDSIGStubber, FontDataRead, MutFontDataWrite};
+use c2pa_font_handler::sfnt::font::stub_dsig_stream;
 use clap::Parser;
 
 /// This tool can be used to take a font file and remove the DSIG table from it,
@@ -41,15 +41,10 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Open the input file
     let mut input_file = std::fs::File::open(&args.input)?;
-    // Read the font file
-    let mut font =
-        c2pa_font_handler::sfnt::font::SfntFont::from_reader(&mut input_file)?;
-    // Stub the DSIG table
-    font.stub_dsig()?;
     // Open the output file
     let mut output_file = std::fs::File::create(&args.output)?;
-    // And write the font file
-    font.write(&mut output_file)?;
+    // Perform the DSIG stubbing operation
+    stub_dsig_stream(&mut input_file, &mut output_file)?;
 
     Ok(())
 }

--- a/c2pa-font-handler/src/data.rs
+++ b/c2pa-font-handler/src/data.rs
@@ -22,12 +22,12 @@ use std::{
 
 use crate::{
     error::FontIoError, utils, FontDataChecksum, FontDataExactRead,
-    FontDataWrite, FontTable,
+    FontDataWrite, FontTable, FontTableReader,
 };
 
 /// Generic data structure for reading and writing data (e.g. OTF/WOFF1 tables).
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Data {
     /// The data
     pub(crate) data: Vec<u8>,
@@ -42,6 +42,14 @@ impl Data {
     /// Set the associated data
     pub fn set_data(&mut self, data: Vec<u8>) {
         self.data = data;
+    }
+}
+
+impl<'a> FontTableReader<'a> for Data {
+    type Error = FontIoError;
+
+    fn get_reader(&'a self) -> Result<impl Read + Seek + 'a, Self::Error> {
+        Ok(std::io::Cursor::new(self.data.as_slice()))
     }
 }
 

--- a/c2pa-font-handler/src/error.rs
+++ b/c2pa-font-handler/src/error.rs
@@ -71,12 +71,18 @@ pub enum FontIoError {
     /// The font table is truncated.
     #[error("The font table is truncated: {0}")]
     LoadTableTruncated(FontTag),
+    /// There were no tables found in the font.
+    #[error("No tables were found in the font.")]
+    NoTablesFound,
     /// Save errors.
     #[error("Error saving the font: {0}")]
     SaveError(#[from] FontSaveError),
     /// An error occurred while generating a string from UTF-8 bytes.
     #[error("Error occurred while generating a string from UTF-8 bytes: {0}")]
     StringFromUtf8(#[from] std::string::FromUtf8Error),
+    /// The table associated with the tag was not found.
+    #[error("The font table was not found for tag: {0}")]
+    TableNotFound(FontTag),
     /// When determining the type of font, the magic number was not recognized.
     #[error("An unknown magic number was encountered: {0}")]
     UnknownMagic(u32),

--- a/c2pa-font-handler/src/lib.rs
+++ b/c2pa-font-handler/src/lib.rs
@@ -172,6 +172,14 @@ pub trait FontTable: FontDataChecksum + FontDataWrite {
     }
 }
 
+/// A trait for getting a reader for a font table.
+pub trait FontTableReader<'a> {
+    /// The error type for reading the table.
+    type Error: Into<crate::error::FontIoError>;
+    /// Returns a reader for the font table data.
+    fn get_reader(&'a self) -> Result<impl Read + Seek + 'a, Self::Error>;
+}
+
 /// Represents a font.
 pub trait Font: FontDataRead + MutFontDataWrite {
     /// The header type for the font.

--- a/c2pa-font-handler/src/lib.rs
+++ b/c2pa-font-handler/src/lib.rs
@@ -57,6 +57,8 @@ pub mod error;
 pub(crate) mod magic;
 pub mod sfnt;
 pub mod tag;
+#[cfg(feature = "thumbnails")]
+pub mod thumbnail;
 pub(crate) mod utils;
 #[cfg(feature = "woff")]
 pub mod woff1;

--- a/c2pa-font-handler/src/lib.rs
+++ b/c2pa-font-handler/src/lib.rs
@@ -207,3 +207,23 @@ pub trait FontDSIGStubber {
     /// Stub the DSIG table in the font.
     fn stub_dsig(&mut self) -> Result<(), Self::Error>;
 }
+
+/// Represents the state of the DSIG table in a font.
+pub enum DSIGType {
+    /// The DSIG table is not present in the font.
+    NotPresent,
+    /// The DSIG table is present in the font and valid.
+    Present,
+    /// The DSIG table is present in the font, but it is empty or invalid.
+    Stubbed,
+}
+
+/// A trait for detecting if a font has a DSIG table. This is useful when you
+/// want to check if a font has a DSIG table without actually reading the
+/// entire font data into memory.
+pub trait FontDSIGDetector {
+    /// The error type for detecting the DSIG table.
+    type Error;
+    /// Detects if the font has a DSIG table.
+    fn check_for_dsig(&mut self) -> Result<DSIGType, Self::Error>;
+}

--- a/c2pa-font-handler/src/sfnt/directory.rs
+++ b/c2pa-font-handler/src/sfnt/directory.rs
@@ -164,7 +164,7 @@ impl FontDataExactRead for SfntDirectory {
         offset: u64,
         size: usize,
     ) -> Result<Self, Self::Error> {
-        if size % SfntDirectoryEntry::SIZE != 0 {
+        if !size.is_multiple_of(SfntDirectoryEntry::SIZE) {
             return Err(FontIoError::InvalidSizeForDirectory(size));
         }
         let entry_count = size / SfntDirectoryEntry::SIZE;

--- a/c2pa-font-handler/src/sfnt/font.rs
+++ b/c2pa-font-handler/src/sfnt/font.rs
@@ -13,6 +13,39 @@
 //  limitations under the License.
 
 //! SFNT font.
+//!
+//! The crate provides an implementation of the SFNT font format, which is
+//! used by OpenType and TrueType fonts. It includes functionality for reading
+//! and writing SFNT fonts, as well as stubbing the DSIG table.
+//!
+//! # Stubbing the DSIG Table
+//!
+//! The DSIG table is used to store digital signatures for fonts. This crate
+//! provides functionality to stub the DSIG table, which is useful for
+//! keeping a DSIG if present, but zeroing out the signatures and just having
+//! a stub table. This is useful for fonts that are being modified or
+//! processed (i.e., when adding C2PA), as it allows the font to be saved
+//! without invalidating the signatures.
+//!
+//! The following is an example of how to efficiently stub the DSIG table in a
+//! stream without loading the entire font into memory:
+//!
+//! ```no_run
+//! use std::{
+//!     fs::File,
+//!     io::{BufReader, BufWriter},
+//! };
+//!
+//! use c2pa_font_handler::{error::FontIoError, sfnt::font::stub_dsig_stream};
+//! # fn main() -> Result<(), FontIoError> {
+//! let input_file = File::open("path/to/input/font.ttf")?;
+//! let output_file = File::create("path/to/output/font.ttf")?;
+//! let mut reader = BufReader::new(input_file);
+//! let mut writer = BufWriter::new(output_file);
+//! stub_dsig_stream(&mut reader, &mut writer)?;
+//! # Ok(())
+//! # }
+//! ```
 
 use std::{
     collections::{btree_map::Entry, BTreeMap},
@@ -35,9 +68,9 @@ use crate::{
     sfnt::table::TableC2PA,
     tag::FontTag,
     utils::align_to_four,
-    Font, FontDSIGStubber, FontDataChecksum, FontDataExactRead, FontDataRead,
-    FontDataWrite, FontDirectory, FontDirectoryEntry, FontHeader, FontTable,
-    MutFontDataWrite,
+    DSIGType, Font, FontDSIGDetector, FontDSIGStubber, FontDataChecksum,
+    FontDataExactRead, FontDataRead, FontDataWrite, FontDirectory,
+    FontDirectoryEntry, FontHeader, FontTable, MutFontDataWrite,
 };
 
 /// Implementation of an SFNT font.
@@ -207,6 +240,80 @@ impl FontDSIGStubber for SfntFont {
         }
         Ok(())
     }
+}
+
+impl<T: Read + Seek + ?Sized> FontDSIGDetector for T {
+    type Error = FontIoError;
+
+    fn check_for_dsig(&mut self) -> Result<crate::DSIGType, Self::Error> {
+        // Grab the original position.
+        let original_position = self.stream_position()?;
+        // We need to parse the header to be able to read the table directory.
+        let font_header = SfntHeader::from_reader(self)?;
+        // And now we can read the table directory.
+        let font_directory = SfntDirectory::from_reader_with_count(
+            self,
+            font_header.numTables as usize,
+        )?;
+        let dsig_type = match font_directory
+            .entries()
+            .iter()
+            .find(|e| e.tag == FontTag::DSIG)
+        {
+            Some(entry) => {
+                // Since DSIG table, according to the spec, must be at the end
+                // of the file we can use the offset to
+                // determine where the end of the font data is.
+                let original_dsig_offset = entry.offset();
+                let dsig_table = TableDSIG::from_reader_exact(
+                    self,
+                    original_dsig_offset as u64,
+                    entry.length() as usize,
+                )?;
+                if dsig_table.is_stubbed() {
+                    tracing::debug!("DSIG table is stubbed.");
+                    DSIGType::Stubbed
+                } else {
+                    tracing::debug!("DSIG table is present and not stubbed.");
+                    // If it is not stubbed, we can return that it is present.
+                    DSIGType::Present
+                }
+            }
+            None => {
+                tracing::debug!("DSIG table is not present.");
+                DSIGType::NotPresent
+            }
+        };
+        self.seek(std::io::SeekFrom::Start(original_position))?;
+        Ok(dsig_type)
+    }
+}
+
+/// A convenience function to stub the DSIG table in a stream. This will
+/// read the stream, check for the DSIG table, and if it is present, stub
+/// it. If the DSIG table is not present or already stubbed, it will simply
+/// copy the stream to the writer without modification.
+pub fn stub_dsig_stream<R: Read + Seek + ?Sized, W: std::io::Write + ?Sized>(
+    reader: &mut R,
+    writer: &mut W,
+) -> Result<(), FontIoError> {
+    match reader.check_for_dsig()? {
+        DSIGType::NotPresent | DSIGType::Stubbed => {
+            tracing::debug!(
+                "DSIG table is not present or already stubbed, copying stream."
+            );
+            std::io::copy(reader, writer)?;
+        }
+        DSIGType::Present => {
+            tracing::debug!(
+                "DSIG table is present and not stubbed, proceeding to stub it."
+            );
+            let mut sfnt_font = SfntFont::from_reader(reader)?;
+            sfnt_font.stub_dsig()?;
+            sfnt_font.write(writer)?;
+        }
+    };
+    Ok(())
 }
 
 impl C2PASupport for SfntFont {

--- a/c2pa-font-handler/src/sfnt/table/dsig.rs
+++ b/c2pa-font-handler/src/sfnt/table/dsig.rs
@@ -58,6 +58,14 @@ impl TableDSIG {
             data: Vec::new(),
         }
     }
+
+    /// Check if this DSIG table is a stub.
+    pub(crate) fn is_stubbed(&self) -> bool {
+        self.version == Self::DEFAULT_VERSION
+            && self.numSignatures == 0
+            && self.flags == Self::DO_NOT_RESIGN
+            && self.data.is_empty()
+    }
 }
 
 impl FontDataExactRead for TableDSIG {

--- a/c2pa-font-handler/src/sfnt/table/dsig_test.rs
+++ b/c2pa-font-handler/src/sfnt/table/dsig_test.rs
@@ -141,3 +141,42 @@ fn test_table_dsig_length() {
     };
     assert_eq!(dsig.len(), 8);
 }
+
+#[test]
+fn test_table_dsig_is_stubbed() {
+    // Verify the "stub()" is actually stubbed
+    let dsig = TableDSIG::stub();
+    assert!(dsig.is_stubbed());
+    assert_eq!(dsig.version, 1);
+    assert_eq!(dsig.numSignatures, 0);
+    assert_eq!(dsig.flags, 1);
+    assert!(dsig.data.is_empty());
+
+    // Now look like a stub, but with a different version
+    let dsig = TableDSIG {
+        version: 10,
+        ..TableDSIG::stub()
+    };
+    assert!(!dsig.is_stubbed());
+
+    // Now look like a stub, but with a different numSignatures
+    let dsig = TableDSIG {
+        numSignatures: 10,
+        ..TableDSIG::stub()
+    };
+    assert!(!dsig.is_stubbed());
+
+    // Now look like a stub, but with a different flags
+    let dsig = TableDSIG {
+        flags: 10,
+        ..TableDSIG::stub()
+    };
+    assert!(!dsig.is_stubbed());
+
+    // Now look like a stub, but with data
+    let dsig = TableDSIG {
+        data: vec![1, 2, 3],
+        ..TableDSIG::stub()
+    };
+    assert!(!dsig.is_stubbed());
+}

--- a/c2pa-font-handler/src/thumbnail.rs
+++ b/c2pa-font-handler/src/thumbnail.rs
@@ -1,0 +1,125 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Thumbnail handling for C2PA fonts.
+
+use std::{
+    fs::File,
+    io::{Read, Seek},
+};
+
+pub(crate) mod error;
+#[cfg(feature = "png-thumbnails")]
+pub(crate) mod png_thumbnail;
+#[cfg(feature = "png-thumbnails")]
+pub use png_thumbnail::{PngThumbnailRenderer, PngThumbnailRendererConfig};
+
+#[cfg(feature = "svg-thumbnails")]
+pub(crate) mod svg_thumbnail;
+#[cfg(feature = "svg-thumbnails")]
+pub use svg_thumbnail::{SvgThumbnailRenderer, SvgThumbnailRendererConfig};
+
+pub(crate) mod text;
+use text::TextFontSystemContext;
+pub use text::{CosmicTextThumbnailGenerator, FontSystemConfig};
+
+/// Represents a thumbnail.
+#[derive(Debug)]
+pub struct Thumbnail {
+    /// The raw data of the thumbnail.
+    pub(crate) data: Vec<u8>,
+    /// The mime type of the thumbnail.
+    pub(crate) mime_type: String,
+}
+
+impl Thumbnail {
+    /// Create a new thumbnail with the given data and mime type.
+    #[allow(dead_code)]
+    fn new(data: Vec<u8>, mime_type: String) -> Self {
+        Self { data, mime_type }
+    }
+
+    /// Get the data of the thumbnail.
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Get the mime type of the thumbnail.
+    pub fn mime_type(&self) -> &str {
+        &self.mime_type
+    }
+}
+
+/// Trait for rendering thumbnails.
+#[cfg_attr(test, mockall::automock)]
+pub trait Renderer {
+    /// Render the thumbnail to a writer.
+    ///
+    /// # Parameters
+    /// - `writer`: A mutable reference to a writer that implements `Write`.
+    ///
+    /// # Errors
+    /// Returns an error if the thumbnail could not be rendered.
+    fn render_thumbnail(
+        &self,
+        text_system_context: &mut TextFontSystemContext,
+    ) -> Result<Thumbnail, error::FontThumbnailError>;
+}
+
+/// Marker trait for types that can read and seek.
+pub trait ReadSeek: Read + Seek {}
+impl<T: Read + Seek + ?Sized> ReadSeek for T {}
+
+/// Support for creating thumbnails for font software.
+pub trait ThumbnailGenerator {
+    /// Create a thumbnail for the font.
+    ///
+    /// This function will create a thumbnail for the font, which can be used
+    /// in C2PA operations.
+    ///
+    /// # Parameters
+    /// - `path`: The path to the font file for which the thumbnail should be
+    ///   created.
+    ///
+    /// # Errors
+    /// Returns an error if the thumbnail could not be created.
+    ///
+    /// # Remarks
+    /// The default implementation will use [`std::fs::File`] to read the
+    /// font file.
+    fn create_thumbnail(
+        &self,
+        path: &std::path::Path,
+    ) -> Result<Thumbnail, error::FontThumbnailError> {
+        let mut reader =
+            File::open(path).map_err(error::FontThumbnailError::IoError)?;
+        self.create_thumbnail_from_stream(&mut reader)
+    }
+
+    /// Create a thumbnail from a stream.
+    ///
+    /// This function will create a thumbnail for the font from a reader stream,
+    /// which can be used in C2PA operations.
+    ///
+    /// # Parameters
+    /// - `reader`: A mutable reference to a reader that implements `Read` and
+    ///   `Seek`.
+    ///
+    /// # Errors
+    /// Returns an error if the thumbnail could not be created from the stream.
+    fn create_thumbnail_from_stream(
+        &self,
+        reader: &mut (dyn ReadSeek),
+    ) -> Result<Thumbnail, error::FontThumbnailError>;
+}

--- a/c2pa-font-handler/src/thumbnail/error.rs
+++ b/c2pa-font-handler/src/thumbnail/error.rs
@@ -1,0 +1,58 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Thumbnail error types.
+
+/// Errors that can occur when creating a font thumbnail
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum FontThumbnailError {
+    /// Error from the image crate
+    #[cfg(feature = "png-thumbnails")]
+    #[error(transparent)]
+    ImageError(#[from] image::ImageError),
+    /// error from IO operations
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    /// A font was not found
+    #[error("No font found")]
+    NoFontFound,
+    /// No full name found in the font
+    #[error("No full name found")]
+    NoFullNameFound,
+    /// Error when the buffer size is invalid
+    #[error("The buffer size is invalid")]
+    InvalidBufferSize,
+    #[cfg(feature = "svg-thumbnails")]
+    /// Could not create a Rect from the given values
+    #[error("Invalid values for Rect")]
+    InvalidRect,
+    /// Failed to find a point size that would accommodate the width and text
+    #[error("Failed to find an appropriate font point size to fit the width")]
+    FailedToFindAppropriateSize,
+    /// Failed to create a Pixmap object
+    #[error("Failed to create pixmap")]
+    FailedToCreatePixmap,
+    /// Failed to get a pixel from the image
+    #[error("Failed to get pixel from image; x: {x}, y: {y}")]
+    FailedToGetPixel { x: u32, y: u32 },
+    /// Failed to create a SVG tree from string
+    #[cfg(feature = "svg-thumbnails")]
+    #[error("Failed to create a SVG tree from string: {0}")]
+    FailedToCreateSvgTree(String),
+    #[cfg(not(feature = "svg-thumbnails"))]
+    /// The SVG feature is not enabled
+    #[error("The SVG feature is not enabled")]
+    SvgFeatureNotEnabled,
+}

--- a/c2pa-font-handler/src/thumbnail/png_thumbnail.rs
+++ b/c2pa-font-handler/src/thumbnail/png_thumbnail.rs
@@ -1,0 +1,239 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Thumbnail handling for C2PA fonts using PNG format.
+
+use tiny_skia::Pixmap;
+
+use super::{text::TextFontSystemContext, Renderer};
+use crate::thumbnail::error::FontThumbnailError;
+
+/// Get a Skia paint object for the given color.
+///
+/// This function converts a `cosmic_text::Color` into a `tiny_skia::Paint`
+/// object, which can be used for drawing operations in the thumbnail renderer.
+///
+/// # Remarks
+/// The `tiny_skia::Paint` object is configured with a solid color shader,
+/// anti-aliasing enabled, and a blend mode set to `Color`. The color is
+/// converted from the `cosmic_text::Color` to a `tiny_skia::Color` using
+/// the `as_rgba_tuple` method, which provides the RGBA components of the color.
+fn get_skia_paint_for_color<'a>(
+    color: cosmic_text::Color,
+) -> tiny_skia::Paint<'a> {
+    tiny_skia::Paint {
+        shader: tiny_skia::Shader::SolidColor({
+            let (r, g, b, a) = color.as_rgba_tuple();
+            tiny_skia::Color::from_rgba8(r, g, b, a)
+        }),
+        blend_mode: tiny_skia::BlendMode::Color,
+        anti_alias: true,
+        ..Default::default()
+    }
+}
+
+/// Configuration for the PNG thumbnail renderer.
+#[derive(Debug, Clone)]
+pub struct PngThumbnailRendererConfig {
+    /// The color to use for the text in the thumbnail.
+    text_color: cosmic_text::Color,
+    /// The background color for the thumbnail
+    background_color: tiny_skia::Color,
+}
+
+impl PngThumbnailRendererConfig {
+    /// The default background color for the thumbnail
+    pub const DEFAULT_BACKGROUND_COLOR: tiny_skia::Color =
+        tiny_skia::Color::WHITE;
+    /// The default text color for the thumbnail
+    pub const DEFAULT_TEXT_COLOR: cosmic_text::Color =
+        cosmic_text::Color::rgba(0, 0, 0, 0xff);
+
+    /// Create a new PNG thumbnail renderer configuration
+    pub fn new<CT: Into<cosmic_text::Color>, BC: Into<tiny_skia::Color>>(
+        text_color: CT,
+        background_color: BC,
+    ) -> Self {
+        Self {
+            text_color: text_color.into(),
+            background_color: background_color.into(),
+        }
+    }
+}
+
+impl Default for PngThumbnailRendererConfig {
+    fn default() -> Self {
+        Self::new(
+            PngThumbnailRendererConfig::DEFAULT_TEXT_COLOR,
+            PngThumbnailRendererConfig::DEFAULT_BACKGROUND_COLOR,
+        )
+    }
+}
+
+/// Renderer for PNG thumbnails from font data.
+pub struct PngThumbnailRenderer {
+    /// Configuration for the PNG thumbnail renderer.
+    config: PngThumbnailRendererConfig,
+}
+
+impl PngThumbnailRenderer {
+    /// The MIME type for PNG images
+    const MIME_TYPE: &'static str = "image/png";
+
+    /// Create a new PNG thumbnail renderer with the given configuration.
+    pub fn new(config: PngThumbnailRendererConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for PngThumbnailRenderer {
+    fn default() -> Self {
+        Self::new(PngThumbnailRendererConfig::default())
+    }
+}
+
+impl Renderer for PngThumbnailRenderer {
+    fn render_thumbnail(
+        &self,
+        text_system_context: &mut TextFontSystemContext,
+    ) -> Result<super::Thumbnail, super::error::FontThumbnailError> {
+        let angle = text_system_context.angle;
+        let (font_system, swash_cache, text_buffer) =
+            text_system_context.mut_cosmic_text_parts();
+        // Got some reason, the `swash` library used by `cosmic-text` puts
+        // pixels at negative x values, so we need to find the amount we
+        // need to offset the image by to include all pixels.
+        let layout_run = text_buffer
+            .layout_runs()
+            .next()
+            .ok_or(FontThumbnailError::InvalidBufferSize)?;
+        // Grab the cache key for the first glyph, so we can get the image
+        // information from the swash cache
+        let x = layout_run
+            .glyphs
+            .first()
+            .ok_or(FontThumbnailError::InvalidBufferSize)?
+            .physical((0., 0.), 1.0)
+            .cache_key;
+        let image = swash_cache
+            .get_image(font_system, x)
+            .as_ref()
+            .ok_or(FontThumbnailError::FailedToCreatePixmap)?;
+        // Only offset if the left is negative
+        let offset = if image.placement.left < 0 {
+            image.placement.left.abs()
+        } else {
+            0
+        };
+
+        // Borrow the buffer with the font system, to make things easier to make
+        // calls
+        let mut buffer = text_buffer.borrow_with(font_system);
+
+        // Grab the actual width and height of the buffer for the image,
+        // verifying that the sizes are sane.
+        let width = buffer.size().0.unwrap_or(-1.0);
+        let height = buffer.size().1.unwrap_or(-1.0);
+        if width < 0.0 || height < 0.0 {
+            return Err(FontThumbnailError::InvalidBufferSize);
+        }
+
+        // Calculate the width taken up by the italic angle
+        let width_italic_buffer = match angle {
+            // If we have an angle get the tangent of the angle
+            Some(angle) => {
+                height * ((std::f32::consts::PI / 180.0) * angle).tan()
+            }
+            // Otherwise, use 0
+            _ => 0.0,
+        }
+        .abs();
+
+        // The total width will be our specified width + the width from the
+        // italic angle. QUESTION: Should not the `cosmic-text` library
+        // really already include this in the width calculation? Are we doing
+        // something wrong?
+        // TODO: Investigate whether `cosmic-text` library already includes
+        // the italic angle in the width calculation. Verify if this
+        // additional calculation is necessary or if it indicates a potential
+        // issue.
+        let width = width + width_italic_buffer + offset as f32;
+
+        // Create a new pixel map for the main text
+        let mut img = tiny_skia::Pixmap::new(width as u32, height as u32)
+            .ok_or(FontThumbnailError::FailedToCreatePixmap)?;
+        // Draw the text into the pixel map
+        buffer.draw(swash_cache, self.config.text_color, |x, y, w, h, color| {
+            if let Some(rect) = tiny_skia::Rect::from_xywh(
+                (x + offset) as f32,
+                y as f32,
+                w as f32,
+                h as f32,
+            )
+            .map(Some)
+            .unwrap_or_default()
+            {
+                img.fill_rect(
+                    rect,
+                    &get_skia_paint_for_color(color),
+                    tiny_skia::Transform::identity(),
+                    None,
+                );
+            } else {
+                tracing::warn!(
+                    "WARN: Failed to create rect: x: {x}, y: {y}, w: {w}, h: {h}"
+                );
+            }
+        });
+
+        // Create a pixel map for the total image
+        let mut final_img = Pixmap::new(width as u32, height as u32)
+            .ok_or(FontThumbnailError::FailedToCreatePixmap)?;
+        // Fill the image in with black to start
+        final_img.fill(self.config.background_color);
+        // Draw the main text into the final image
+        final_img.draw_pixmap(
+            0,
+            0,
+            img.as_ref(),
+            &tiny_skia::PixmapPaint::default(),
+            tiny_skia::Transform::identity(),
+            None,
+        );
+        // Now use the `image` crate to save the final image as a PNG as
+        // grayscale, because as of now, `tiny-skia` does not support
+        // saving as PNG with grayscale
+        // Convert the Pixmap to an RgbaImage
+        let rgba_image = image::RgbaImage::from_raw(
+            final_img.width(),
+            final_img.height(),
+            final_img.data().to_vec(),
+        )
+        .ok_or(FontThumbnailError::FailedToCreatePixmap)?;
+        // Convert the RgbaImage to grayscale
+        let gray_image =
+            image::DynamicImage::ImageRgba8(rgba_image).grayscale();
+        let mut png_buffer = Vec::new();
+        let mut png_cursor = std::io::Cursor::new(&mut png_buffer);
+        gray_image.write_to(&mut png_cursor, image::ImageFormat::Png)?;
+        Ok(super::Thumbnail::new(
+            png_buffer,
+            Self::MIME_TYPE.to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+#[path = "png_thumbnail_test.rs"]
+mod tests;

--- a/c2pa-font-handler/src/thumbnail/png_thumbnail_test.rs
+++ b/c2pa-font-handler/src/thumbnail/png_thumbnail_test.rs
@@ -1,0 +1,135 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Tests for PNG thumbnail generation.
+
+use std::io::Cursor;
+
+use super::*;
+use crate::thumbnail::text::{create_font_system, FontSystemConfig};
+
+/// Sets up a test context with a dummy font system and swash cache.
+fn setup_cosmic_text_for_test() -> TextFontSystemContext {
+    let mut font_data =
+        Cursor::new(include_bytes!("../../../.devtools/font.otf"));
+    create_font_system(&FontSystemConfig::default(), &mut font_data).unwrap()
+}
+
+#[test]
+fn test_get_skia_paint_for_color() {
+    let color = cosmic_text::Color::rgba(255, 0, 0, 255);
+    let skia_paint_color = get_skia_paint_for_color(color);
+    assert_eq!(skia_paint_color.blend_mode, tiny_skia::BlendMode::Color);
+    assert!(skia_paint_color.anti_alias);
+    assert!(matches!(
+        skia_paint_color.shader,
+        tiny_skia::Shader::SolidColor(_)
+    ));
+}
+
+#[test]
+fn test_default_png_thumbnail_renderer_config() {
+    let config = PngThumbnailRendererConfig::default();
+    assert_eq!(
+        config.text_color,
+        PngThumbnailRendererConfig::DEFAULT_TEXT_COLOR
+    );
+    assert_eq!(
+        config.background_color,
+        PngThumbnailRendererConfig::DEFAULT_BACKGROUND_COLOR
+    );
+}
+
+#[test]
+fn test_new_png_thumbnail_renderer_config() {
+    let text_color = cosmic_text::Color::rgba(0, 128, 0, 255);
+    let background_color = tiny_skia::Color::from_rgba8(255, 255, 0, 255);
+    let config = PngThumbnailRendererConfig::new(text_color, background_color);
+
+    assert_eq!(config.text_color, text_color);
+    assert_eq!(config.background_color, background_color);
+}
+
+#[test]
+fn test_default_png_thumbnail_renderer() {
+    let renderer = PngThumbnailRenderer::default();
+    assert_eq!(
+        renderer.config.text_color,
+        PngThumbnailRendererConfig::DEFAULT_TEXT_COLOR
+    );
+    assert_eq!(
+        renderer.config.background_color,
+        PngThumbnailRendererConfig::DEFAULT_BACKGROUND_COLOR
+    );
+    let mut context = setup_cosmic_text_for_test();
+    let result = renderer.render_thumbnail(&mut context);
+    assert!(result.is_ok());
+    let thumbnail = result.unwrap();
+    assert_eq!(thumbnail.mime_type(), "image/png");
+    assert!(!thumbnail.data().is_empty());
+    assert!(thumbnail.data().starts_with(b"\x89PNG\r\n\x1a\n"));
+}
+
+// Verify the error path when the buffer size is invalid
+#[test]
+fn test_png_thumbnail_renderer_invalid_size() {
+    let config = PngThumbnailRendererConfig::default();
+    let renderer = PngThumbnailRenderer::new(config);
+    let mut context = setup_cosmic_text_for_test();
+
+    // Setup test parameters
+    {
+        let (font_system, _swash_cache, buffer) =
+            context.mut_cosmic_text_parts();
+        buffer.set_size(font_system, None, Some(18.0));
+    }
+    // Attempt to render a thumbnail with invalid size
+    let result = renderer.render_thumbnail(&mut context);
+
+    // Expect an error due to invalid size
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert!(matches!(error, FontThumbnailError::InvalidBufferSize));
+
+    // Now set invalid height
+    {
+        let (font_system, _swash_cache, buffer) =
+            context.mut_cosmic_text_parts();
+        buffer.set_size(font_system, Some(18.0), None);
+    }
+    // Attempt to render a thumbnail with invalid height
+    let result = renderer.render_thumbnail(&mut context);
+    // Expect an error due to invalid height
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert!(matches!(error, FontThumbnailError::InvalidBufferSize));
+}
+
+// Verify rendering a PNG when the angle is None
+#[test]
+fn test_png_thumbnail_renderer_none_angle() {
+    let config = PngThumbnailRendererConfig::default();
+    let renderer = PngThumbnailRenderer::new(config);
+    let mut context = setup_cosmic_text_for_test();
+
+    context.angle = None; // Set angle to None
+                          // Attempt to render a thumbnail with invalid size
+    let result = renderer.render_thumbnail(&mut context);
+
+    // Expect an error due to invalid size
+    assert!(result.is_ok());
+    let error = result.unwrap();
+    assert_eq!(error.mime_type(), "image/png");
+    assert!(!error.data().is_empty());
+}

--- a/c2pa-font-handler/src/thumbnail/svg_thumbnail.rs
+++ b/c2pa-font-handler/src/thumbnail/svg_thumbnail.rs
@@ -1,0 +1,262 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Thumbnail handling for C2PA fonts using SVG format.
+
+use resvg::usvg::{Options, Tree};
+use svg::{
+    node::element::{Group, Style},
+    Document, Node,
+};
+
+use super::{text::TextFontSystemContext, Renderer};
+use crate::thumbnail::error::FontThumbnailError;
+
+/// Trait for rounding values to a specified precision.
+trait PrecisionRound {
+    fn round_to(&self, precision: u32) -> Self;
+}
+
+// Implement PrecisionRound for f32
+impl PrecisionRound for f32 {
+    fn round_to(&self, precision: u32) -> Self {
+        let factor = 10u32.pow(precision) as f32;
+        (self * factor).round() / factor
+    }
+}
+
+// Implement PrecisionRound for (f32, f32)
+impl PrecisionRound for (f32, f32) {
+    fn round_to(&self, precision: u32) -> Self {
+        (self.0.round_to(precision), self.1.round_to(precision))
+    }
+}
+
+/// Configuration for the SVG thumbnail renderer.
+///
+/// # Remarks
+/// This configuration allows customization of the SVG thumbnail rendering,
+/// including the precision of the coordinates and the fill color for the
+/// glyphs.
+///
+/// Default values are provided for both precision and fill color, but they can
+/// be overridden when creating an instance of this configuration.
+#[derive(Clone, Debug)]
+pub struct SvgThumbnailRendererConfig {
+    /// The default precision for rounding SVG coordinates
+    pub(crate) default_precision: u32,
+    /// The fill color for the glyphs in the SVG thumbnail
+    pub(crate) glyph_fill_color: String,
+}
+
+impl SvgThumbnailRendererConfig {
+    /// Default precision for SVG values.
+    pub const DEFAULT_SVG_PRECISION: u32 = 2;
+    /// Default fill color for glyphs in SVG thumbnails.
+    pub const SVG_GLYPH_FILL_COLOR: &'static str = "black";
+
+    /// Create a new SVG thumbnail renderer configuration.
+    pub fn new<S: Into<String>>(
+        default_precision: u32,
+        glyph_fill_color: S,
+    ) -> Self {
+        Self {
+            default_precision,
+            glyph_fill_color: glyph_fill_color.into(),
+        }
+    }
+}
+
+impl Default for SvgThumbnailRendererConfig {
+    fn default() -> Self {
+        Self::new(
+            SvgThumbnailRendererConfig::DEFAULT_SVG_PRECISION,
+            SvgThumbnailRendererConfig::SVG_GLYPH_FILL_COLOR.to_string(),
+        )
+    }
+}
+
+/// Renderer for SVG thumbnails from font data.
+pub struct SvgThumbnailRenderer {
+    /// Configuration for the SVG thumbnail renderer.
+    config: SvgThumbnailRendererConfig,
+}
+
+impl SvgThumbnailRenderer {
+    /// The name of the SVG fill attribute.
+    const FILL: &'static str = "fill";
+    /// The MIME type for SVG thumbnails.
+    const MIME_TYPE: &'static str = "image/svg+xml";
+    /// The name of the SVG path element.
+    const PATH: &'static str = "path";
+    /// The scale transformation to flip the SVG vertically.
+    const SCALE: &'static str = "scale(1, -1)";
+    /// The name of the SVG transform attribute.
+    const TRANSFORM: &'static str = "transform";
+    /// The viewBox attribute for the SVG document.
+    const VIEW_BOX: &'static str = "viewBox";
+
+    /// Create a new SVG thumbnail renderer with the given configuration.
+    pub fn new(config: SvgThumbnailRendererConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for SvgThumbnailRenderer {
+    fn default() -> Self {
+        Self::new(SvgThumbnailRendererConfig::default())
+    }
+}
+
+impl Renderer for SvgThumbnailRenderer {
+    fn render_thumbnail(
+        &self,
+        text_system_context: &mut TextFontSystemContext,
+    ) -> Result<super::Thumbnail, super::error::FontThumbnailError> {
+        let precision = self.config.default_precision;
+        tracing::trace!("Rendering SVG thumbnail with precision: {precision}");
+        let mut svg_doc = Document::new();
+        let mut tmp_doc = Document::new();
+        let (font_system, swash_cache, text_buffer) =
+            text_system_context.mut_cosmic_text_parts();
+        for layout_run in text_buffer.layout_runs() {
+            let mut group = Group::new();
+            // Add a style to have the fill as black and the stroke to none
+            group = group.add(Style::new(
+                format!(
+                    "{} {{ {}: {}; }}",
+                    Self::PATH,
+                    Self::FILL,
+                    self.config.glyph_fill_color
+                )
+                .as_str(),
+            ));
+            for glyph in layout_run.glyphs {
+                let mut data = svg::node::element::path::Data::new();
+                // Get the x/y offsets
+                let (x_offset, y_offset) =
+                    (glyph.x + glyph.x_offset, glyph.y + glyph.y_offset);
+                // We will need the physical glyph to get the outline commands
+                let physical_glyph = glyph.physical((0., 0.), 1.0);
+                let cache_key = physical_glyph.cache_key;
+                let outline_commands =
+                    swash_cache.get_outline_commands(font_system, cache_key);
+                // Go through each command and build the path
+                if let Some(commands) = outline_commands {
+                    for command in commands {
+                        match command {
+                            cosmic_text::Command::MoveTo(p1) => {
+                                let rounded_data =
+                                    (p1.x, p1.y).round_to(precision);
+                                data = data.move_to(rounded_data);
+                            }
+                            cosmic_text::Command::LineTo(p1) => {
+                                let rounded_data =
+                                    (p1.x, p1.y).round_to(precision);
+                                data = data.line_to(rounded_data);
+                            }
+                            cosmic_text::Command::CurveTo(p1, p2, p3) => {
+                                let p1_rounded_data =
+                                    (p1.x, p1.y).round_to(precision);
+                                let p2_rounded_data =
+                                    (p2.x, p2.y).round_to(precision);
+                                let p3_rounded_data =
+                                    (p3.x, p3.y).round_to(precision);
+                                data = data.cubic_curve_to((
+                                    p1_rounded_data,
+                                    p2_rounded_data,
+                                    p3_rounded_data,
+                                ));
+                            }
+                            cosmic_text::Command::QuadTo(p1, p2) => {
+                                let p1_rounded_data =
+                                    (p1.x, p1.y).round_to(precision);
+                                let p2_rounded_data =
+                                    (p2.x, p2.y).round_to(precision);
+                                data = data.quadratic_curve_to((
+                                    p1_rounded_data,
+                                    p2_rounded_data,
+                                ));
+                            }
+                            cosmic_text::Command::Close => {
+                                data = data.close();
+                            }
+                        }
+                    }
+                }
+                // Don't add empty data paths
+                if !data.is_empty() {
+                    let path = svg::node::element::Path::new()
+                        .set(
+                            Self::TRANSFORM,
+                            format!("translate({x_offset}, {y_offset})"),
+                        )
+                        .set("d", data.clone());
+                    group = group.add(path);
+                }
+            }
+
+            group.assign(Self::TRANSFORM, Self::SCALE);
+            // We will need to create a temporary document to get the bounding
+            // box of the entire group
+            tmp_doc = tmp_doc.add(group.clone());
+            svg_doc.append(group);
+        }
+        // Convert the temporary document to a string, so we can get the
+        // bounding box
+        let svg_str = tmp_doc.to_string();
+        // Generate the SVG tree from the string
+        let tree =
+            Tree::from_str(&svg_str, &Options::default()).map_err(|e| {
+                tracing::trace!(
+                    "Failed to create SVG tree from string: {svg_str}"
+                );
+                tracing::error!("Failed to create SVG tree with error: {e}");
+                FontThumbnailError::FailedToCreateSvgTree(svg_str)
+            })?;
+        // Round the bounding box outwards and then convert it to a rect
+        let bounding_box = tree
+            .root()
+            .abs_bounding_box()
+            .round_out()
+            .ok_or(FontThumbnailError::InvalidRect)?
+            .to_rect();
+        // Set the view box with a 1-pixel padding around the bounding box, as
+        // there are some corner cases (when the font is bold?) where
+        // the bounding box is not quite right and 1 pixel row is being
+        // clipped for items where the character goes below the
+        // baseline.
+        svg_doc = svg_doc.set(
+            Self::VIEW_BOX,
+            (
+                bounding_box.x() - 1.0,
+                bounding_box.y() - 1.0,
+                bounding_box.width() + 2.0,
+                bounding_box.height() + 2.0,
+            ),
+        );
+
+        let mut svg_buffer = Vec::new();
+        let svg_cursor = std::io::Cursor::new(&mut svg_buffer);
+        svg::write(svg_cursor, &svg_doc)?;
+        Ok(super::Thumbnail::new(
+            svg_buffer,
+            SvgThumbnailRenderer::MIME_TYPE.to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+#[path = "svg_thumbnail_test.rs"]
+mod tests;

--- a/c2pa-font-handler/src/thumbnail/svg_thumbnail_test.rs
+++ b/c2pa-font-handler/src/thumbnail/svg_thumbnail_test.rs
@@ -1,0 +1,91 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Tests for SVG thumbnail generation.
+
+use std::io::Cursor;
+
+use super::*;
+use crate::thumbnail::text::{create_font_system, FontSystemConfig};
+
+/// Sets up a test context with a dummy font system and swash cache.
+fn setup_cosmic_text_for_test() -> TextFontSystemContext {
+    let mut font_data =
+        Cursor::new(include_bytes!("../../../.devtools/font.otf"));
+    create_font_system(&FontSystemConfig::default(), &mut font_data).unwrap()
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn test_svg_renderer() {
+    // Create a dummy font system and swash cache
+    let mut context = setup_cosmic_text_for_test();
+
+    // Create the SVG thumbnail renderer
+    let renderer =
+        SvgThumbnailRenderer::new(SvgThumbnailRendererConfig::default());
+
+    // Render a thumbnail using the renderer
+    let result = renderer.render_thumbnail(&mut context);
+    // Check if the result is Ok
+    assert!(result.is_ok());
+
+    let thumbnail = result.unwrap();
+    assert_eq!("image/svg+xml", thumbnail.mime_type());
+    assert!(!thumbnail.data().is_empty());
+    assert!(thumbnail.data().starts_with(b"<svg"));
+}
+
+#[test]
+fn test_svg_renderer_default() {
+    // Create a default SVG thumbnail renderer
+    let renderer = SvgThumbnailRenderer::default();
+
+    // Check if the default precision is set correctly
+    assert_eq!(
+        renderer.config.default_precision,
+        SvgThumbnailRendererConfig::DEFAULT_SVG_PRECISION
+    );
+    // Check if the default fill color is set correctly
+    assert_eq!(
+        renderer.config.glyph_fill_color,
+        SvgThumbnailRendererConfig::SVG_GLYPH_FILL_COLOR
+    );
+}
+
+#[test]
+fn test_precision_rounding() {
+    // Test rounding for f32
+    let value: f32 = 1.234_567_9;
+    let rounded_value = value.round_to(3);
+    assert_eq!(rounded_value, 1.235);
+
+    // Test rounding for (f32, f32)
+    let point: (f32, f32) = (1.234_567_9, 2.345_678_9);
+    let rounded_point = point.round_to(3);
+    assert_eq!(rounded_point, (1.235, 2.346));
+}
+
+#[test]
+fn test_default_svg_thumbnail_renderer_config() {
+    let config = SvgThumbnailRendererConfig::default();
+    assert_eq!(
+        config.default_precision,
+        SvgThumbnailRendererConfig::DEFAULT_SVG_PRECISION
+    );
+    assert_eq!(
+        config.glyph_fill_color,
+        SvgThumbnailRendererConfig::SVG_GLYPH_FILL_COLOR
+    );
+}

--- a/c2pa-font-handler/src/thumbnail/text.rs
+++ b/c2pa-font-handler/src/thumbnail/text.rs
@@ -1,0 +1,505 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#![allow(dead_code)]
+
+//! This module provides functionality for using the cosmic-text crate
+//! to create a font system for a given font, with no fallback fonts. This is
+//! used to generate thumbnails for fonts, which can be used in C2PA
+//! operations.
+
+use std::{
+    io::{Read, Seek},
+    sync::Arc,
+};
+
+use cosmic_text::{
+    fontdb::{Database, ID},
+    ttf_parser::{name_id, PlatformId},
+    Attrs, BorrowedWithFontSystem, Buffer, CacheKeyFlags, Fallback, Font,
+    FontFeatures, FontSystem, Metrics, SwashCache,
+};
+
+use super::{
+    error::FontThumbnailError, ReadSeek, Renderer, ThumbnailGenerator,
+};
+
+/// Context for the text font system, which includes the font system, swash
+/// cache, text buffer, and the angle of the font if it is italic.
+#[derive(Debug)]
+pub struct TextFontSystemContext {
+    /// The font system to use for rendering text
+    pub font_system: FontSystem,
+    /// The swash cache to use for rendering text
+    pub swash_cache: SwashCache,
+    /// The text buffer to use for rendering text
+    pub text_buffer: Buffer,
+    /// The angle of the font, if it is italic
+    pub angle: Option<f32>,
+}
+
+impl TextFontSystemContext {
+    /// Get the angle of the font if it is italic, otherwise None
+    pub fn angle(&self) -> Option<f32> {
+        self.angle
+    }
+
+    /// Get the cosmic-text parts from the context
+    pub fn mut_cosmic_text_parts(
+        &mut self,
+    ) -> (&mut FontSystem, &mut SwashCache, &mut Buffer) {
+        (
+            &mut self.font_system,
+            &mut self.swash_cache,
+            &mut self.text_buffer,
+        )
+    }
+}
+
+/// A thumbnail generator that uses the cosmic-text crate to render text
+/// thumbnails. This generator is designed to create thumbnails for fonts
+/// without any fallback fonts, which is useful for C2PA operations where
+/// fallback fonts are not desired.
+pub struct CosmicTextThumbnailGenerator<'a> {
+    /// The underlying renderer that will be used to render the thumbnail
+    renderer: Box<dyn Renderer>,
+    /// The font system configuration to use for the thumbnail generation
+    font_system_config: FontSystemConfig<'a>,
+}
+
+impl<'a> CosmicTextThumbnailGenerator<'a> {
+    /// Create a new SVG thumbnail generator with the given renderer.
+    pub fn new(render: Box<dyn Renderer>) -> Self {
+        Self {
+            renderer: render,
+            font_system_config: FontSystemConfig::default(),
+        }
+    }
+
+    /// Create a new SVG thumbnail generator with the given renderer.
+    pub fn new_with_config(
+        renderer: Box<dyn Renderer>,
+        font_system_config: FontSystemConfig<'a>,
+    ) -> Self {
+        Self {
+            renderer,
+            font_system_config,
+        }
+    }
+}
+
+impl<'a> ThumbnailGenerator for CosmicTextThumbnailGenerator<'a> {
+    fn create_thumbnail_from_stream(
+        &self,
+        reader: &mut (dyn ReadSeek),
+    ) -> Result<super::Thumbnail, super::error::FontThumbnailError> {
+        let mut context = create_font_system(&self.font_system_config, reader)?;
+        self.renderer.render_thumbnail(&mut context)
+    }
+}
+
+/// Information about the font
+struct FontNameInfo {
+    /// Full name of the font
+    full_name: Option<String>,
+    /// Sample text for the font
+    #[allow(unused)]
+    sample_text: Option<String>,
+}
+
+impl From<Arc<Font>> for FontNameInfo {
+    fn from(font: Arc<Font>) -> Self {
+        // The US English language ID; currently localization is still a work in
+        // progress
+        const US_EN_LANGUAGE_ID: u16 = 0x0409;
+        // The Unicode BMP encoding
+        const UNICODE_BMP_ENCODING: u16 = 3;
+        // The Windows Symbol encoding
+        const WINDOWS_SYMBOL_ENCODING: u16 = 0;
+        // The Windows BMP encoding
+        const WINDOWS_BMP_ENCODING: u16 = 1;
+
+        let face = font.rustybuzz();
+        // We want to use PlatformID::Unicode/LanguageID::English for the name
+        // table when possible, if not available, we will look for
+        // Windows, and then finally Macintosh
+        let preferred_search_order = [
+            (PlatformId::Unicode, US_EN_LANGUAGE_ID, UNICODE_BMP_ENCODING),
+            (
+                PlatformId::Windows,
+                US_EN_LANGUAGE_ID,
+                WINDOWS_SYMBOL_ENCODING,
+            ),
+            (PlatformId::Windows, US_EN_LANGUAGE_ID, WINDOWS_BMP_ENCODING),
+        ];
+
+        let find_name = |name_id: u16| {
+            preferred_search_order
+                .iter()
+                .find_map(|&(platform, lang, encoding)| {
+                    face.names().into_iter().find(|n| {
+                        n.name_id == name_id
+                            && n.platform_id == platform
+                            && n.language_id == lang
+                            && n.encoding_id == encoding
+                    })
+                })
+                .and_then(|name| name.to_string())
+        };
+
+        let full_name = find_name(name_id::FULL_NAME);
+        let sample_text = find_name(name_id::SAMPLE_TEXT);
+
+        FontNameInfo {
+            full_name,
+            sample_text,
+        }
+    }
+}
+
+/// Information about a loaded font, including its ID and attributes.
+#[derive(Debug)]
+struct LoadedFont<'a> {
+    /// The ID of the loaded font in the font database
+    id: ID,
+    /// The attributes of the loaded font
+    attrs: Attrs<'a>,
+}
+
+/// Load font data into the font database, returning the ID of the loaded font
+fn load_font_data<'a>(
+    font_db: &mut Database,
+    font_data: Vec<u8>,
+) -> Result<LoadedFont<'a>, FontThumbnailError> {
+    font_db.load_font_data(font_data);
+    let face = font_db
+        .faces()
+        .last()
+        .ok_or(FontThumbnailError::NoFontFound)?;
+    let weight = face.weight;
+    let style = face.style;
+    let stretch = face.stretch;
+    let attrs: Attrs = Attrs {
+        color_opt: None,
+        family: cosmic_text::Family::Serif,
+        stretch,
+        style,
+        weight,
+        metadata: 0,
+        cache_key_flags: CacheKeyFlags::empty(),
+        metrics_opt: None,
+        letter_spacing_opt: None,
+        font_features: FontFeatures::new(),
+    };
+    Ok(LoadedFont { id: face.id, attrs })
+}
+
+/// The cosmic-text crate provides a [`Fallback`] trait that is used to provide
+/// fallback fonts In our scenario, we do not want to use any fallback fonts for
+/// generating the thumbnail, so we implement a no-op version of the trait
+#[derive(Default)]
+struct NoFallback {}
+
+impl Fallback for NoFallback {
+    fn common_fallback(&self) -> &[&'static str] {
+        &[]
+    }
+
+    fn forbidden_fallback(&self) -> &[&'static str] {
+        &[]
+    }
+
+    fn script_fallback(
+        &self,
+        _script: unicode_script::Script,
+        _locale: &str,
+    ) -> &[&'static str] {
+        &[]
+    }
+}
+
+/// Configuration for the font system used to generate thumbnails
+#[derive(Debug, Clone)]
+pub struct FontSystemConfig<'a> {
+    /// The default locale to use for the font system
+    default_locale: &'a str,
+    /// The line height factor for the thumbnail
+    line_height_factor: f32,
+    /// The maximum width for the thumbnail
+    maximum_width: u32,
+    /// The minimum point size for the font system
+    minimum_point_size: f32,
+    /// The step size to reduce the point size when searching for a fitting
+    /// width
+    point_size_step: f32,
+    /// The starting point size for the font system
+    starting_point_size: f32,
+    /// The total width padding to apply to the thumbnail
+    total_width_padding: f32,
+}
+
+impl FontSystemConfig<'static> {
+    /// Default locale for the font system
+    const DEFAULT_LOCALE: &'static str = "en-US";
+    /// The line height factor for the thumbnail
+    const LINE_HEIGHT_FACTOR: f32 = 1.075;
+    /// Maximum width for the thumbnail
+    const MAXIMUM_WIDTH: u32 = 400;
+    /// Minimum point size for the font system
+    const MINIMUM_POINT_SIZE: f32 = 6.0;
+    /// Step size to reduce the point size when searching for a fitting width
+    const POINT_SIZE_STEP: f32 = 8.0;
+    /// Starting point size for the font system
+    const STARTING_POINT_SIZE: f32 = 512.0;
+    /// Total width padding to apply to the thumbnail
+    const TOTAL_WIDTH_PADDING: f32 = 0.1; // 10% padding
+}
+
+impl<'a> FontSystemConfig<'a> {
+    /// Create a new font system configuration with the given parameters
+    pub fn new(
+        default_locale: &'a str,
+        line_height_factor: f32,
+        maximum_width: u32,
+        minimum_point_size: f32,
+        point_size_step: f32,
+        starting_point_size: f32,
+        total_width_padding: f32,
+    ) -> Self {
+        Self {
+            default_locale,
+            line_height_factor,
+            maximum_width,
+            minimum_point_size,
+            point_size_step,
+            starting_point_size,
+            total_width_padding,
+        }
+    }
+}
+
+impl Default for FontSystemConfig<'static> {
+    fn default() -> Self {
+        Self {
+            default_locale: Self::DEFAULT_LOCALE,
+            line_height_factor: Self::LINE_HEIGHT_FACTOR,
+            maximum_width: Self::MAXIMUM_WIDTH,
+            minimum_point_size: Self::MINIMUM_POINT_SIZE,
+            point_size_step: Self::POINT_SIZE_STEP,
+            starting_point_size: Self::STARTING_POINT_SIZE,
+            total_width_padding: Self::TOTAL_WIDTH_PADDING,
+        }
+    }
+}
+
+/// For a given stream of font data, create a font system and a buffer that fits
+/// the given width and height, ready for rendering.
+///
+/// # Parameters
+/// - `config`: The configuration for the font system.
+/// - `stream`: The stream containing the font data.
+///
+/// # Returns
+/// A tuple containing the buffer, font system, swash cache, and angle (if
+/// italic).
+pub fn create_font_system<R: Read + Seek + ?Sized>(
+    config: &FontSystemConfig,
+    stream: &mut R,
+) -> Result<TextFontSystemContext, FontThumbnailError> {
+    let font_data =
+        std::io::Read::bytes(stream).collect::<std::io::Result<Vec<u8>>>()?;
+    // Create a local font database, which only contains the font we loaded
+    let mut font_db = Database::new();
+    // Load the given font file into the font database, getting the ID of the
+    // font to use with the font system
+    let loaded_font: LoadedFont = load_font_data(&mut font_db, font_data)?;
+
+    // And build a font system from this local database
+    let mut font_system =
+        cosmic_text::FontSystem::new_with_locale_and_db_and_fallback(
+            config.default_locale.to_string(),
+            font_db.clone(),
+            NoFallback::default(),
+        );
+    // Get reference to the font from the font system
+    let f = font_system
+        .get_font(loaded_font.id)
+        .ok_or(FontThumbnailError::NoFontFound)?;
+    // Grab the potential italic angle of the font to calculate the width
+    // of the slant later
+    let angle = f.rustybuzz().italic_angle();
+    let font_info = FontNameInfo::from(f.clone());
+    let full_name = font_info
+        .full_name
+        .ok_or(FontThumbnailError::NoFullNameFound)?;
+
+    // Create a swash cache for the font system, to cache rendering
+    let swash_cache = SwashCache::new();
+
+    let ascender = f.rustybuzz().ascender() as i32;
+    let descender = f.rustybuzz().descender() as i32;
+    let max_height: f32 =
+        (ascender - descender) as f32 / f.rustybuzz().units_per_em() as f32;
+
+    // Find a buffer that fits the width
+    let buffer = get_buffer_with_pt_size_fits_width(
+        &full_name,
+        loaded_font.attrs.clone(),
+        &mut font_system,
+        config,
+        |x| (max_height * config.line_height_factor * x).ceil(),
+    )?;
+
+    //Ok((buffer, font_system, swash_cache, angle))
+    Ok(TextFontSystemContext {
+        font_system,
+        swash_cache,
+        text_buffer: buffer,
+        angle,
+    })
+}
+
+/// Finds the point size that fits the width and creates a buffer with the text
+/// and has it ready for rendering.
+///
+/// # Remarks
+/// The `line_height_fn` is a function that takes the font size and should be
+/// used to calculate the line height.
+fn get_buffer_with_pt_size_fits_width<T: Fn(f32) -> f32>(
+    text: &str,
+    attrs: Attrs,
+    font_system: &mut FontSystem,
+    config: &FontSystemConfig,
+    line_height_fn: T,
+) -> Result<Buffer, FontThumbnailError> {
+    // Starting point size
+    let mut font_size: f32 = config.starting_point_size;
+    // Generate the line height from the font height
+    let mut line_height: f32 = line_height_fn(font_size);
+
+    // Make sure there is a enough room for line wrapping to account for the
+    // width being too small
+    let height = line_height * 2.5;
+    let width =
+        config.maximum_width as f32 * (1.0 - config.total_width_padding);
+
+    // Create a buffer for measuring the text
+    let mut buffer =
+        Buffer::new(font_system, Metrics::new(font_size, line_height));
+    let mut borrowed_buffer = buffer.borrow_with(font_system);
+
+    // Loop until we find the right size to fit within the maximum width
+    while font_size > config.minimum_point_size {
+        borrowed_buffer.set_size(Some(width), Some(height));
+        borrowed_buffer.set_wrap(cosmic_text::Wrap::Glyph);
+        borrowed_buffer.set_text(text, &attrs, cosmic_text::Shaping::Advanced);
+        borrowed_buffer.shape_until_scroll(true);
+        // Get the number of layout runs, we expect one if it fits on one line
+        let count = borrowed_buffer.layout_runs().count();
+        // If it is one, we have found the right size
+        if count == 1 {
+            let size = measure_text(text, &attrs, &mut borrowed_buffer)?;
+            // There instances where the measured width was 0, but maybe this is
+            // caught now by counting the number of layout runs?
+            if size.w > 0.0 && size.w <= width {
+                borrowed_buffer.set_size(Some(size.w), Some(size.h));
+                return Ok(buffer);
+            }
+        }
+        // Adjust and prepare to try again
+        font_size -= config.point_size_step;
+        line_height = line_height_fn(font_size);
+
+        // Update the buffer with the new font size
+        borrowed_buffer.set_metrics(Metrics::new(font_size, line_height));
+    }
+    // At this point we have reached our minimum size, so setup to use it
+    // which will result in text clipping, but that is fine
+    font_size = config.minimum_point_size;
+    line_height = line_height_fn(font_size);
+    borrowed_buffer.set_size(Some(width), Some(line_height));
+    borrowed_buffer.set_metrics(Metrics::new(font_size, line_height));
+    borrowed_buffer.shape_until_scroll(true);
+    // get the text replacing the last 3 characters with ellipsis
+    let text = if text.len() > 3 {
+        format!("{}...", text.split_at(text.len() - 3).0)
+    } else {
+        text.to_string()
+    };
+    borrowed_buffer.set_text(&text, &attrs, cosmic_text::Shaping::Advanced);
+    let size = measure_text(&text, &attrs, &mut borrowed_buffer)?;
+    // We still run the chance of an invalid size returned, so take that into
+    // account
+    if size.w > 0.0 && size.w <= width && size.h <= height {
+        borrowed_buffer.set_size(Some(size.w), Some(size.h));
+        return Ok(buffer);
+    }
+    Err(FontThumbnailError::FailedToFindAppropriateSize)
+}
+
+/// Size of the bounding box
+#[derive(Debug, Default, Clone)]
+struct Size {
+    /// Width of the bounding box
+    w: f32,
+    /// Height of the bounding box
+    h: f32,
+}
+
+/// Measure the text to get the size of the bounding box required
+///
+/// # Remarks
+/// The width may come back as `0.0` if the text is empty or the buffer width is
+/// too small.
+fn measure_text(
+    text: &str,
+    attrs: &Attrs,
+    buffer: &mut BorrowedWithFontSystem<Buffer>,
+) -> Result<Size, FontThumbnailError> {
+    buffer.set_text(text, attrs, cosmic_text::Shaping::Advanced);
+    buffer.shape_until_scroll(true);
+    measure_text_in_buffer(buffer)
+}
+
+/// Measure the text in the buffer to get the size of the bounding box required
+///
+/// # Remarks
+/// The width may come back as `0.0` if the text is empty or the buffer width is
+/// too small.
+fn measure_text_in_buffer(
+    buffer: &mut BorrowedWithFontSystem<Buffer>,
+) -> Result<Size, FontThumbnailError> {
+    let buffer_width = buffer.size().0.unwrap_or(-1.0);
+    let buffer_height = buffer.size().1.unwrap_or(-1.0);
+
+    // Error if the buffer is not a valid/sane looking size
+    if buffer_width < 0.0 || buffer_height < 0.0 {
+        return Err(FontThumbnailError::InvalidBufferSize);
+    }
+    // Find the maximum width of the layout lines and keep track of the total
+    // number of lines
+    let (width, total_lines) = buffer
+        .layout_runs()
+        .fold((0.0, 0usize), |(width, total_lines), run| {
+            (run.line_w.max(width), total_lines + 1)
+        });
+    Ok(Size {
+        w: width,
+        h: total_lines as f32 * buffer.metrics().line_height,
+    })
+}
+
+#[cfg(test)]
+#[path = "./text_test.rs"]
+mod tests;

--- a/c2pa-font-handler/src/thumbnail/text_test.rs
+++ b/c2pa-font-handler/src/thumbnail/text_test.rs
@@ -1,0 +1,308 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Tests for the text portion of font thumbnails.
+
+use std::io::Cursor;
+
+use cosmic_text::{fontdb::Database, Buffer, Fallback, FontSystem, Metrics};
+
+use super::{
+    create_font_system, measure_text, measure_text_in_buffer, NoFallback,
+};
+use crate::thumbnail::{
+    error::FontThumbnailError,
+    text::{load_font_data, FontNameInfo, FontSystemConfig, LoadedFont},
+    CosmicTextThumbnailGenerator, ThumbnailGenerator,
+};
+
+// Test converting a Arc<Font> to a FontNameInfo
+#[test]
+fn test_font_name_info_conversion() {
+    let font_data = include_bytes!("../../../.devtools/font.otf");
+    let mut font_database = Database::new();
+    let LoadedFont { id: font_id, .. } =
+        load_font_data(&mut font_database, font_data.to_vec()).unwrap();
+    let mut font_system = FontSystem::new_with_locale_and_db(
+        "en-US".to_string(),
+        font_database.clone(),
+    );
+    let font = font_system.get_font(font_id).unwrap();
+
+    let font_name_info: FontNameInfo = FontNameInfo::from(font);
+    assert_eq!(
+        font_name_info.full_name,
+        Some("AnEmptyFont Regular".to_string())
+    );
+    assert_eq!(font_name_info.sample_text, None);
+}
+
+// Verify the NoFallback implementation does not provide any fallback scripts.
+#[test]
+fn test_no_fallback_callbacks() {
+    let no_fallback = NoFallback {};
+    let result =
+        no_fallback.script_fallback(unicode_script::Script::Common, "en-US");
+    assert_eq!(result.len(), 0, "Expected no fallback scripts");
+    let result = no_fallback.common_fallback();
+    assert_eq!(result.len(), 0, "Expected no common fallback scripts");
+    let result = no_fallback.forbidden_fallback();
+    assert_eq!(result.len(), 0, "Expected no fallback for script");
+}
+
+// Check the construction of the FontSystemConfig struct.
+#[test]
+fn test_new_font_system_config() {
+    let config =
+        FontSystemConfig::new("en-US", 4.20, 1024, 8.0, 2.3, 7.7, 100.0);
+    assert_eq!(
+        config.default_locale, "en-US",
+        "Expected default locale to be 'en-US'"
+    );
+    assert_eq!(
+        config.line_height_factor, 4.20,
+        "Expected line height factor to be 4.20"
+    );
+    assert_eq!(
+        config.maximum_width, 1024,
+        "Expected max text width to be 1024"
+    );
+    assert_eq!(
+        config.minimum_point_size, 8.0,
+        "Expected minimum point size to be 8.0"
+    );
+    assert_eq!(
+        config.point_size_step, 2.3,
+        "Expected point size step to be 2.3"
+    );
+    assert_eq!(
+        config.starting_point_size, 7.7,
+        "Expected starting point size to be 7.7"
+    );
+    assert_eq!(
+        config.total_width_padding, 100.0,
+        "Expected total width padding to be 100.0"
+    );
+}
+
+#[test]
+fn test_create_font_system() {
+    let config = FontSystemConfig::default();
+    let font_data = include_bytes!("../../../.devtools/font.otf");
+    let mut stream = Cursor::new(font_data);
+    let result = create_font_system(&config, &mut stream);
+    assert!(result.is_ok(), "Expected successful font system creation");
+}
+
+// We should be able to measure text with a valid text buffer and attributes.
+#[test]
+fn test_measure_text() {
+    let text_str = "Hello, World!";
+    let metrics = Metrics::new(10.0, 18.0);
+    let mut font_system = FontSystem::new();
+    let mut text_buffer = Buffer::new(&mut font_system, metrics);
+    let mut buffer = text_buffer.borrow_with(&mut font_system);
+    buffer.set_size(Some(30.0), Some(30.0));
+    let attrs = cosmic_text::Attrs::new();
+    let result = measure_text(text_str, &attrs, &mut buffer);
+    assert!(result.is_ok(), "Expected successful measurement");
+    let size = result.unwrap();
+    let (width, height) = (size.w, size.h);
+    assert!(width > 0.0, "Expected width to be greater than 0.0");
+    assert!(height > 0.0, "Expected height to be greater than 0.0");
+}
+
+#[test]
+fn test_create_font_system_with_clipping() {
+    let config = FontSystemConfig {
+        default_locale: "en-US",
+        maximum_width: 100,
+        minimum_point_size: 80.0, /* Point size to make sure we do not have
+                                   * enough space to fit the text, but can
+                                   * clip it. */
+        ..Default::default()
+    };
+    let font_data = include_bytes!("../../../.devtools/font.otf");
+    let mut stream = Cursor::new(font_data);
+    let result = create_font_system(&config, &mut stream);
+    assert!(result.is_ok(), "Expected successful font system creation with clipping; got error: {result:?}");
+    let mut context = result.unwrap();
+    assert_eq!(Some(0.0), context.angle());
+    let (_font_system, _swash_cache, text_buffer) =
+        context.mut_cosmic_text_parts();
+    assert!(
+        matches!(text_buffer.size(), (Some(_), Some(_))),
+        "Expected buffer size to be set, got: {:?}",
+        text_buffer.size()
+    );
+}
+
+#[test]
+fn test_create_font_system_failing_to_find_appropriate_size() {
+    let config = FontSystemConfig {
+        minimum_point_size: 8.0,
+        total_width_padding: 100.0,
+        ..Default::default()
+    };
+    let font_data = include_bytes!("../../../.devtools/font.otf");
+    let mut stream = Cursor::new(font_data);
+    let result = create_font_system(&config, &mut stream);
+    assert!(
+        result.is_err(),
+        "Expected to fail to create font system creation"
+    );
+    let error = result.unwrap_err();
+    assert!(
+        matches!(error, FontThumbnailError::FailedToFindAppropriateSize),
+        "Expected error to be FailedToFindAppropriateSize; found: {error:?}"
+    );
+    // Check that the text buffer is created with the correct size
+}
+
+// Test the method correctly catches when the text buffer is an incorrect size.
+#[test]
+fn test_measure_text_in_buffer_invalid_buffer_size() {
+    let metrics = Metrics::new(10.0, 18.0);
+    let mut font_system = FontSystem::new();
+    let mut text_buffer = Buffer::new(&mut font_system, metrics);
+
+    text_buffer.set_size(&mut font_system, None, Some(18.0));
+    let mut borrowed_buffer = text_buffer.borrow_with(&mut font_system);
+
+    let result = measure_text_in_buffer(&mut borrowed_buffer);
+    assert!(result.is_err(), "Expected an error for invalid buffer size");
+    let error = result.unwrap_err();
+    assert!(matches!(error, FontThumbnailError::InvalidBufferSize));
+
+    text_buffer.set_size(&mut font_system, Some(18.0), None);
+    let mut borrowed_buffer = text_buffer.borrow_with(&mut font_system);
+
+    let result = measure_text_in_buffer(&mut borrowed_buffer);
+    assert!(result.is_err(), "Expected an error for invalid buffer size");
+    let error = result.unwrap_err();
+    assert!(matches!(error, FontThumbnailError::InvalidBufferSize));
+}
+
+// Test the method correctly measures text in a valid buffer.
+#[test]
+fn test_measure_text_in_buffer() {
+    let metrics = Metrics::new(10.0, 18.0);
+    let mut font_system = FontSystem::new();
+    let mut text_buffer = Buffer::new(&mut font_system, metrics);
+
+    // Set the size correctly
+    text_buffer.set_size(&mut font_system, Some(18.0), Some(18.0));
+    let mut borrowed_buffer = text_buffer.borrow_with(&mut font_system);
+
+    // Measure the text in the buffer
+    let result = measure_text_in_buffer(&mut borrowed_buffer);
+    assert!(result.is_ok(), "Expected successful measurement");
+
+    // Check that the result is as expected
+    let size = result.unwrap();
+    let (width, height) = (size.w, size.h);
+    // Since we haven't actually used any text, the width should be 0.0
+    assert_eq!(width, 0.0, "Expected width to be 0.0");
+    assert_eq!(height, 18.0, "Expected height to be 18.0");
+}
+
+#[test]
+fn test_new_cosmic_text_thumbnail_generator() {
+    let mut renderer = crate::thumbnail::MockRenderer::new();
+    renderer.expect_render_thumbnail().returning(|_| {
+        Ok(crate::thumbnail::Thumbnail::new(
+            b"<svg></svg>".to_vec(),
+            "image/svg+xml".to_string(),
+        ))
+    });
+    let renderer = Box::new(renderer);
+    let generator = CosmicTextThumbnailGenerator::new(renderer);
+    let mut font_data =
+        Cursor::new(include_bytes!("../../../.devtools/font.otf"));
+    let result = generator.create_thumbnail_from_stream(&mut font_data);
+    assert!(result.is_ok(), "Expected successful thumbnail creation");
+    let thumbnail = result.unwrap();
+    assert_eq!(
+        "image/svg+xml",
+        thumbnail.mime_type(),
+        "Expected mime type to be 'image/svg+xml'"
+    );
+    assert!(
+        !thumbnail.data().is_empty(),
+        "Expected thumbnail data to not be empty"
+    );
+    assert!(
+        thumbnail.data().starts_with(b"<svg"),
+        "Expected thumbnail data to start with '<svg'"
+    );
+}
+
+#[test]
+fn test_cosmic_text_thumbnail_generator_with_font_system_config() {
+    let font_system_config = FontSystemConfig::default();
+    let mut renderer = crate::thumbnail::MockRenderer::new();
+    renderer.expect_render_thumbnail().returning(|_| {
+        Ok(crate::thumbnail::Thumbnail::new(
+            b"<svg></svg>".to_vec(),
+            "image/svg+xml".to_string(),
+        ))
+    });
+    let renderer = Box::new(renderer);
+    let generator = CosmicTextThumbnailGenerator::new_with_config(
+        renderer,
+        font_system_config,
+    );
+    let mut font_data =
+        Cursor::new(include_bytes!("../../../.devtools/font.otf"));
+    let result = generator.create_thumbnail_from_stream(&mut font_data);
+    // Check if the result is Ok
+    assert!(result.is_ok());
+    let thumbnail = result.unwrap();
+    assert_eq!("image/svg+xml", thumbnail.mime_type());
+    assert!(!thumbnail.data().is_empty());
+    assert!(thumbnail.data().starts_with(b"<svg"));
+}
+
+#[test]
+fn test_new_cosmic_text_thumbnail_generator_from_path() {
+    let mut renderer = crate::thumbnail::MockRenderer::new();
+    renderer.expect_render_thumbnail().returning(|_| {
+        Ok(crate::thumbnail::Thumbnail::new(
+            b"<svg></svg>".to_vec(),
+            "image/svg+xml".to_string(),
+        ))
+    });
+    let renderer = Box::new(renderer);
+    let generator = CosmicTextThumbnailGenerator::new(renderer);
+    // Build up the font path using the Cargo workspace root
+    let font_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../.devtools/font.otf");
+
+    let result = generator.create_thumbnail(&font_path);
+    assert!(result.is_ok(), "Expected successful thumbnail creation");
+    let thumbnail = result.unwrap();
+    assert_eq!(
+        "image/svg+xml",
+        thumbnail.mime_type(),
+        "Expected mime type to be 'image/svg+xml'"
+    );
+    assert!(
+        !thumbnail.data().is_empty(),
+        "Expected thumbnail data to not be empty"
+    );
+    assert!(
+        thumbnail.data().starts_with(b"<svg"),
+        "Expected thumbnail data to start with '<svg'"
+    );
+}

--- a/c2pa-font-handler/src/woff1/directory.rs
+++ b/c2pa-font-handler/src/woff1/directory.rs
@@ -165,7 +165,7 @@ impl FontDataExactRead for Woff1Directory {
         offset: u64,
         size: usize,
     ) -> Result<Self, Self::Error> {
-        if size % Woff1DirectoryEntry::SIZE != 0 {
+        if !size.is_multiple_of(Woff1DirectoryEntry::SIZE) {
             return Err(FontIoError::InvalidSizeForDirectory(size));
         }
         let entry_count = size / Woff1DirectoryEntry::SIZE;

--- a/c2pa-font-handler/src/woff1/table/named_table.rs
+++ b/c2pa-font-handler/src/woff1/table/named_table.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 
 /// Various types of tables by name
+#[derive(Clone, Debug)]
 pub enum NamedTable {
     /// 'C2PA' table
     C2PA(TableC2PA),

--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,4 @@
-# @copyright 2024 Monotype Imaging Inc.
+# @copyright 2024-2025 Monotype Imaging Inc.
 #
 # @file deny.toml
 #
@@ -17,20 +17,24 @@ targets = [
 
 # Deny all advisories unless explicitly ignored.
 [advisories]
+yanked = "deny"
 version = 2
 ignore = []
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow" # "deny" # TODO: Change to "deny" when ready.
 
 wildcards = "deny"
 
 [licenses]
 allow = [
   "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
   "MIT",
   "Unicode-3.0",
+  "Zlib",
 ]
 version = 2
 confidence-threshold = 0.8

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -17,4 +17,4 @@
 # @brief Rust toolchain configuration file.
 #
 [toolchain]
-channel = "1.82"
+channel = "1.87"


### PR DESCRIPTION
<!--  Title should use the format: "ISSUE-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/ISSUE-123/featureName"  -->
<!--        Branch names for Bugs: "fix/ISSUE-123/bugFixName"       -->
# Issue(s)

- 

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [ ] **Merge Commit** will be updated with `(MAJOR)` | `(MINOR)` when appropriate
- [ ] **PR labeled** appropriately
- [ ] Changes include a single fix/feature
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [ ] **Test case(s)** added
  - [ ] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

This release fixes a feature that stabilized in 1.87 of rust, which was causing nightly failures on `main`. Additionally, it contains

* The ability to generate thumbnails for SFNT
* Fixes for WOFF1 support
* Ability to convert WOFF1 to SFNT - readying support for WOFF1 thumbnails
* Better checks for DSIG (and whether it is stubbed)

# Verification Instructions
<!-- Instructions for checking or testing this change. -->