### PR TITLE
C2PA-689/C2PA-690: (MINOR) Generate thumbnails for WOFF1 files.

### DIFF
--- a/c2pa-font-handler/ReadMe.md
+++ b/c2pa-font-handler/ReadMe.md
@@ -20,8 +20,8 @@ Feature|Note|On by Default
 -|-|-
 `compression`|Turns on support for compression, using the `flate` feature|❌ No
 `flate`|Compiles the `flate2` crate|❌ No
-`png-thumbnails`|Adds the ability to create PNG thumbnails for SFNT files|❌ No
-`svg-thumbnails`|Adds the ability to create SVG thumbnails for SFNT files|✅ Yes
+`png-thumbnails`|Adds the ability to create PNG thumbnails for SFNT (and WOFF1) files|❌ No
+`svg-thumbnails`|Adds the ability to create SVG thumbnails for SFNT (and WOFF1) files|✅ Yes
 `thumbnails`|Use of `cosmic-text` crate for generating thumbnails; `png-thumbnails` and/or `svg-thumbnails` turn this on when used.|✅ Yes
 `woff`|Turns on support for WOFF fonts (this is currently a work in progress)|❌ No
 
@@ -34,6 +34,8 @@ The [render_thumbnails](./examples/render_thumbnail.rs) example is provided to s
 ```shell
 cargo run --features="svg-thumbnails png-thumbnails" --example "render_thumbnail" -- -t svg --input "path/to/font.otf" --output "path/to/thumbnail.svg"
 ```
+
+> NOTE: Since `woff` feature is not on by default, you must also specify `woff` to generate a thumbnail for a WOFF1 file.
 
 ### `stub_dsig`
 

--- a/c2pa-font-handler/benches/thumbnails.rs
+++ b/c2pa-font-handler/benches/thumbnails.rs
@@ -41,7 +41,10 @@ fn sfnt_thumbnail_benchmarks(c: &mut Criterion) {
             ));
             let generator = CosmicTextThumbnailGenerator::new(svg_renderer);
             let _ = generator
-                .create_thumbnail_from_stream(&mut font_stream)
+                .create_thumbnail_from_stream(
+                    &mut font_stream,
+                    Some("font/otf"),
+                )
                 .unwrap();
         });
     });
@@ -56,7 +59,10 @@ fn sfnt_thumbnail_benchmarks(c: &mut Criterion) {
             ));
             let generator = CosmicTextThumbnailGenerator::new(png_renderer);
             let _ = generator
-                .create_thumbnail_from_stream(&mut font_stream)
+                .create_thumbnail_from_stream(
+                    &mut font_stream,
+                    Some("font/otf"),
+                )
                 .unwrap();
         });
     });

--- a/c2pa-font-handler/src/lib.rs
+++ b/c2pa-font-handler/src/lib.rs
@@ -55,6 +55,7 @@ pub mod compression;
 pub mod data;
 pub mod error;
 pub(crate) mod magic;
+pub mod mime_type;
 pub mod sfnt;
 pub mod tag;
 #[cfg(feature = "thumbnails")]

--- a/c2pa-font-handler/src/mime_type.rs
+++ b/c2pa-font-handler/src/mime_type.rs
@@ -1,0 +1,74 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Help with MIME types for font files.
+
+use std::io::{Read, Seek};
+
+/// MIME types for common font formats.
+pub struct MimeTypes {}
+
+impl MimeTypes {
+    /// MIME type for OpenType font files.
+    pub const OTF: &str = "font/otf";
+    /// MIME type for TrueType font files.
+    pub const TTF: &str = "font/ttf";
+    /// MIME type for WOFF font files.
+    pub const WOFF: &str = "font/woff";
+    /// MIME type for WOFF2 font files.
+    pub const WOFF2: &str = "font/woff2";
+}
+
+/// A way to guess the MIME type from an object.
+pub trait MimeTypeGuesser {
+    /// The error type for the MIME type guessing.
+    type Error;
+
+    /// Guess the MIME type of the file based on its contents.
+    fn guess_mime_type(&mut self) -> Result<String, Self::Error>;
+}
+
+impl<T: Read + Seek + ?Sized> MimeTypeGuesser for T {
+    type Error = std::io::Error;
+
+    fn guess_mime_type(&mut self) -> Result<String, Self::Error> {
+        // Grab the current position so we can rewind later
+        let current_position = self.stream_position()?;
+        // Read the first few bytes to determine the MIME type
+        let mut buffer = [0; 8];
+        let mut reader = self.take(8);
+        reader.read_exact(&mut buffer)?;
+
+        // Rewind the reader to the original position
+        self.seek(std::io::SeekFrom::Start(current_position))?;
+
+        // Check for common font file signatures
+        if buffer.starts_with(b"\x00\x01\x00\x00")
+            || buffer.starts_with(b"\x4F\x54\x54\x4F")
+        {
+            Ok(MimeTypes::OTF.to_string())
+        } else if buffer.starts_with(b"\x00\x01\x00\x00") {
+            Ok(MimeTypes::TTF.to_string())
+        } else if buffer.starts_with(b"\x77\x4F\x46\x46") {
+            Ok(MimeTypes::WOFF.to_string())
+        } else if buffer.starts_with(b"\x77\x4F\x46\x46\x32") {
+            Ok(MimeTypes::WOFF2.to_string())
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Unknown font file format",
+            ))
+        }
+    }
+}

--- a/c2pa-font-handler/src/mime_type.rs
+++ b/c2pa-font-handler/src/mime_type.rs
@@ -70,7 +70,7 @@ impl MagicTypes {
 }
 
 /// A way to guess the MIME type from an object.
-pub trait MimeTypeGuesser {
+pub trait FontMimeTypeGuesser {
     /// The error type for the MIME type guessing.
     type Error;
 
@@ -78,7 +78,7 @@ pub trait MimeTypeGuesser {
     fn guess_mime_type(&mut self) -> Result<&'static str, Self::Error>;
 }
 
-impl<T: Read + Seek + ?Sized> MimeTypeGuesser for T {
+impl<T: Read + Seek + ?Sized> FontMimeTypeGuesser for T {
     type Error = std::io::Error;
 
     fn guess_mime_type(&mut self) -> Result<&'static str, Self::Error> {

--- a/c2pa-font-handler/src/mime_type_test.rs
+++ b/c2pa-font-handler/src/mime_type_test.rs
@@ -1,0 +1,57 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Tests for MIME type handling in C2PA font handler.
+
+use super::*;
+
+#[test]
+fn test_guess_mime_type_otf() {
+    let mut reader = std::io::Cursor::new(&b"\x00\x01\x00\x00"[..]);
+    let mime_type = reader.guess_mime_type().unwrap();
+    assert_eq!(mime_type, MimeTypes::OTF);
+
+    let mut reader = std::io::Cursor::new(&b"OTTO"[..]);
+    let mime_type = reader.guess_mime_type().unwrap();
+    assert_eq!(mime_type, MimeTypes::OTF);
+}
+
+#[test]
+fn test_guess_mime_type_ttf() {
+    let mut reader = std::io::Cursor::new(&b"true"[..]);
+    let mime_type = reader.guess_mime_type().unwrap();
+    assert_eq!(mime_type, MimeTypes::TTF);
+}
+
+#[test]
+fn test_guess_mime_type_woff() {
+    let mut reader = std::io::Cursor::new(&b"\x77\x4F\x46\x46"[..]);
+    let mime_type = reader.guess_mime_type().unwrap();
+    assert_eq!(mime_type, MimeTypes::WOFF);
+}
+
+#[test]
+fn test_guess_mime_type_woff2() {
+    let mut reader = std::io::Cursor::new(&b"\x77\x4F\x46\x32"[..]);
+    let mime_type = reader.guess_mime_type().unwrap();
+    assert_eq!(mime_type, MimeTypes::WOFF2);
+}
+
+#[test]
+fn test_guess_mime_type_unknown() {
+    let mut reader = std::io::Cursor::new(&b"unknown"[..]);
+    let result = reader.guess_mime_type();
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+}

--- a/c2pa-font-handler/src/mime_type_test.rs
+++ b/c2pa-font-handler/src/mime_type_test.rs
@@ -53,5 +53,8 @@ fn test_guess_mime_type_unknown() {
     let mut reader = std::io::Cursor::new(&b"unknown"[..]);
     let result = reader.guess_mime_type();
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+    assert!(matches!(
+        result.err().unwrap(),
+        MimeTypeError::UnknownMagicType
+    ));
 }

--- a/c2pa-font-handler/src/thumbnail.rs
+++ b/c2pa-font-handler/src/thumbnail.rs
@@ -34,7 +34,7 @@ pub(crate) mod text;
 use text::TextFontSystemContext;
 pub use text::{CosmicTextThumbnailGenerator, FontSystemConfig};
 
-use crate::mime_type;
+use crate::mime_type::FontMimeTypeGuesser;
 
 /// Represents a thumbnail.
 #[derive(Debug)]
@@ -106,9 +106,8 @@ pub trait ThumbnailGenerator {
     ) -> Result<Thumbnail, error::FontThumbnailError> {
         let mut reader =
             File::open(path).map_err(error::FontThumbnailError::IoError)?;
-        let mime_type =
-            mime_type::MimeTypeGuesser::guess_mime_type(&mut reader)
-                .map_err(error::FontThumbnailError::IoError)?;
+        let mime_type = FontMimeTypeGuesser::guess_mime_type(&mut reader)
+            .map_err(error::FontThumbnailError::IoError)?;
         self.create_thumbnail_from_stream(&mut reader, Some(mime_type))
     }
 

--- a/c2pa-font-handler/src/thumbnail.rs
+++ b/c2pa-font-handler/src/thumbnail.rs
@@ -109,7 +109,7 @@ pub trait ThumbnailGenerator {
         let mime_type =
             mime_type::MimeTypeGuesser::guess_mime_type(&mut reader)
                 .map_err(error::FontThumbnailError::IoError)?;
-        self.create_thumbnail_from_stream(&mut reader, Some(&mime_type))
+        self.create_thumbnail_from_stream(&mut reader, Some(mime_type))
     }
 
     /// Create a thumbnail from a stream.

--- a/c2pa-font-handler/src/thumbnail.rs
+++ b/c2pa-font-handler/src/thumbnail.rs
@@ -106,8 +106,7 @@ pub trait ThumbnailGenerator {
     ) -> Result<Thumbnail, error::FontThumbnailError> {
         let mut reader =
             File::open(path).map_err(error::FontThumbnailError::IoError)?;
-        let mime_type = FontMimeTypeGuesser::guess_mime_type(&mut reader)
-            .map_err(error::FontThumbnailError::IoError)?;
+        let mime_type = FontMimeTypeGuesser::guess_mime_type(&mut reader)?;
         self.create_thumbnail_from_stream(&mut reader, Some(mime_type))
     }
 

--- a/c2pa-font-handler/src/thumbnail.rs
+++ b/c2pa-font-handler/src/thumbnail.rs
@@ -34,6 +34,8 @@ pub(crate) mod text;
 use text::TextFontSystemContext;
 pub use text::{CosmicTextThumbnailGenerator, FontSystemConfig};
 
+use crate::mime_type;
+
 /// Represents a thumbnail.
 #[derive(Debug)]
 pub struct Thumbnail {
@@ -104,7 +106,10 @@ pub trait ThumbnailGenerator {
     ) -> Result<Thumbnail, error::FontThumbnailError> {
         let mut reader =
             File::open(path).map_err(error::FontThumbnailError::IoError)?;
-        self.create_thumbnail_from_stream(&mut reader)
+        let mime_type =
+            mime_type::MimeTypeGuesser::guess_mime_type(&mut reader)
+                .map_err(error::FontThumbnailError::IoError)?;
+        self.create_thumbnail_from_stream(&mut reader, Some(&mime_type))
     }
 
     /// Create a thumbnail from a stream.
@@ -115,11 +120,15 @@ pub trait ThumbnailGenerator {
     /// # Parameters
     /// - `reader`: A mutable reference to a reader that implements `Read` and
     ///   `Seek`.
+    /// - `mime_type`: An optional MIME type of the data represented by the
+    ///   reader. If not provided, the MIME type will be guessed based on the
+    ///   contents of the reader when needed.
     ///
     /// # Errors
     /// Returns an error if the thumbnail could not be created from the stream.
     fn create_thumbnail_from_stream(
         &self,
         reader: &mut dyn ReadSeek,
+        mime_type: Option<&str>,
     ) -> Result<Thumbnail, error::FontThumbnailError>;
 }

--- a/c2pa-font-handler/src/thumbnail/error.rs
+++ b/c2pa-font-handler/src/thumbnail/error.rs
@@ -18,8 +18,8 @@
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum FontThumbnailError {
-    /// An error while reading/writing font data
-    #[error(transparent)]
+    /// Font I/O error while reading the font for thumbnail generation
+    #[error("Error reading font data for thumbnail generation; {0}")]
     FontIoError(#[from] crate::error::FontIoError),
     /// Error from the image crate
     #[cfg(feature = "png-thumbnails")]
@@ -28,6 +28,9 @@ pub enum FontThumbnailError {
     /// error from IO operations
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+    /// Error when guessing the MIME type of the font
+    #[error(transparent)]
+    MimeTypeError(#[from] crate::mime_type::MimeTypeError),
     /// A font was not found
     #[error("No font found")]
     NoFontFound,

--- a/c2pa-font-handler/src/thumbnail/error.rs
+++ b/c2pa-font-handler/src/thumbnail/error.rs
@@ -18,6 +18,9 @@
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum FontThumbnailError {
+    /// An error while reading/writing font data
+    #[error(transparent)]
+    FontIoError(#[from] crate::error::FontIoError),
     /// Error from the image crate
     #[cfg(feature = "png-thumbnails")]
     #[error(transparent)]
@@ -55,4 +58,7 @@ pub enum FontThumbnailError {
     /// The SVG feature is not enabled
     #[error("The SVG feature is not enabled")]
     SvgFeatureNotEnabled,
+    /// The input is not a valid/supported font type
+    #[error("The mime type of the input is not supported")]
+    UnsupportedInputMimeType,
 }

--- a/c2pa-font-handler/src/thumbnail/text.rs
+++ b/c2pa-font-handler/src/thumbnail/text.rs
@@ -20,7 +20,7 @@
 //! operations.
 
 use std::{
-    io::{Cursor, Read, Seek},
+    io::{Read, Seek},
     sync::Arc,
 };
 
@@ -34,7 +34,7 @@ use cosmic_text::{
 use super::{
     error::FontThumbnailError, ReadSeek, Renderer, ThumbnailGenerator,
 };
-use crate::{mime_type, sfnt::font::SfntFont, FontDataRead, MutFontDataWrite};
+use crate::mime_type;
 
 /// Context for the text font system, which includes the font system, swash
 /// cache, text buffer, and the angle of the font if it is italic.
@@ -127,6 +127,11 @@ impl<'a> ThumbnailGenerator for CosmicTextThumbnailGenerator<'a> {
             }
             #[cfg(feature = "woff")]
             mime_type::MimeTypes::WOFF | mime_type::MimeTypes::WOFF2 => {
+                use std::io::Cursor;
+
+                use crate::{
+                    sfnt::font::SfntFont, FontDataRead, MutFontDataWrite,
+                };
                 tracing::trace!("Converting WOFF/WOFF2 to SFNT");
                 // Parse WOFF/WOFF2, convert to SFNT, and render
                 let woff_font =

--- a/c2pa-font-handler/src/thumbnail/text.rs
+++ b/c2pa-font-handler/src/thumbnail/text.rs
@@ -34,7 +34,7 @@ use cosmic_text::{
 use super::{
     error::FontThumbnailError, ReadSeek, Renderer, ThumbnailGenerator,
 };
-use crate::mime_type;
+use crate::mime_type::{self, FontMimeTypeGuesser};
 
 /// Context for the text font system, which includes the font system, swash
 /// cache, text buffer, and the angle of the font if it is italic.
@@ -111,7 +111,7 @@ impl<'a> ThumbnailGenerator for CosmicTextThumbnailGenerator<'a> {
             Some(m) => m,
             None => {
                 tracing::trace!("Guessing MIME type for font data");
-                mime_type::MimeTypeGuesser::guess_mime_type(reader)
+                FontMimeTypeGuesser::guess_mime_type(reader)
                     .map_err(FontThumbnailError::from)?
             }
         };

--- a/c2pa-font-handler/src/thumbnail/text.rs
+++ b/c2pa-font-handler/src/thumbnail/text.rs
@@ -108,7 +108,7 @@ impl<'a> ThumbnailGenerator for CosmicTextThumbnailGenerator<'a> {
     ) -> Result<super::Thumbnail, super::error::FontThumbnailError> {
         // Determine the MIME type, guessing if not provided
         let mime = match mime_type {
-            Some(m) => m.to_owned(),
+            Some(m) => m,
             None => {
                 tracing::trace!("Guessing MIME type for font data");
                 mime_type::MimeTypeGuesser::guess_mime_type(reader)
@@ -117,7 +117,7 @@ impl<'a> ThumbnailGenerator for CosmicTextThumbnailGenerator<'a> {
         };
         tracing::trace!("Attempting to generate thumbnail for source data with MIME type: {mime}");
 
-        match mime.as_str() {
+        match mime {
             mime_type::MimeTypes::OTF | mime_type::MimeTypes::TTF => {
                 tracing::trace!("Creating font system from SFNT data");
                 let mut context =


### PR DESCRIPTION
<!--  Title should use the format: "ISSUE-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/ISSUE-123/featureName"  -->
<!--        Branch names for Bugs: "fix/ISSUE-123/bugFixName"       -->
# Issue(s)

- C2PA-689

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [X] **Merge Commit** will be updated with `(MAJOR)` | `(MINOR)` when appropriate
- [X] **PR labeled** appropriately
- [X] Changes include a single fix/feature
- [X] **Documentation** updated:
  - [X] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [X] **Test case(s)** added
  - [X] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

This PR does the following:

- Changes the thumbnail trait to take a mime type for the stream
- If mime type of source data is not provided it will be guessed
- WOFF file is converted to SFNT
- SFNT then used to generate thumbnail

# Verification Instructions
<!-- Instructions for checking or testing this change. -->

The best way to verify is run the example:

```
cargo run --example render_thumbnail --features="svg-thumbnails woff" -- --input "path/to/font.woff" --output path/to/output/font.woff.svg -t svg
```

And then verify it errors by default when the `woff` feature is not used:

```
cargo run --example render_thumbnail --features="svg-thumbnails" -- --input "path/to/font.woff" --output path/to/output/font.woff.svg -t svg
```