### PR TITLE
release: WOFF1 thumbnail generation and fix for C2PA data location

### DIFF
--- a/c2pa-font-handler/ReadMe.md
+++ b/c2pa-font-handler/ReadMe.md
@@ -20,8 +20,8 @@ Feature|Note|On by Default
 -|-|-
 `compression`|Turns on support for compression, using the `flate` feature|❌ No
 `flate`|Compiles the `flate2` crate|❌ No
-`png-thumbnails`|Adds the ability to create PNG thumbnails for SFNT files|❌ No
-`svg-thumbnails`|Adds the ability to create SVG thumbnails for SFNT files|✅ Yes
+`png-thumbnails`|Adds the ability to create PNG thumbnails for SFNT (and WOFF1) files|❌ No
+`svg-thumbnails`|Adds the ability to create SVG thumbnails for SFNT (and WOFF1) files|✅ Yes
 `thumbnails`|Use of `cosmic-text` crate for generating thumbnails; `png-thumbnails` and/or `svg-thumbnails` turn this on when used.|✅ Yes
 `woff`|Turns on support for WOFF fonts (this is currently a work in progress)|❌ No
 
@@ -34,6 +34,8 @@ The [render_thumbnails](./examples/render_thumbnail.rs) example is provided to s
 ```shell
 cargo run --features="svg-thumbnails png-thumbnails" --example "render_thumbnail" -- -t svg --input "path/to/font.otf" --output "path/to/thumbnail.svg"
 ```
+
+> Note: The `woff` feature is disabled by default. To generate a thumbnail for a WOFF1 file, you must explicitly enable the `woff` feature.
 
 ### `stub_dsig`
 

--- a/c2pa-font-handler/benches/thumbnails.rs
+++ b/c2pa-font-handler/benches/thumbnails.rs
@@ -19,10 +19,13 @@
 mod profiler_utils;
 use std::io::Cursor;
 
-use c2pa_font_handler::thumbnail::{
-    CosmicTextThumbnailGenerator, PngThumbnailRenderer,
-    PngThumbnailRendererConfig, SvgThumbnailRenderer,
-    SvgThumbnailRendererConfig, ThumbnailGenerator,
+use c2pa_font_handler::{
+    mime_type::FontMimeTypes,
+    thumbnail::{
+        CosmicTextThumbnailGenerator, PngThumbnailRenderer,
+        PngThumbnailRendererConfig, SvgThumbnailRenderer,
+        SvgThumbnailRendererConfig, ThumbnailGenerator,
+    },
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use profiler_utils::DhatProfiler;
@@ -41,7 +44,10 @@ fn sfnt_thumbnail_benchmarks(c: &mut Criterion) {
             ));
             let generator = CosmicTextThumbnailGenerator::new(svg_renderer);
             let _ = generator
-                .create_thumbnail_from_stream(&mut font_stream)
+                .create_thumbnail_from_stream(
+                    &mut font_stream,
+                    Some(&FontMimeTypes::OTF),
+                )
                 .unwrap();
         });
     });
@@ -56,7 +62,10 @@ fn sfnt_thumbnail_benchmarks(c: &mut Criterion) {
             ));
             let generator = CosmicTextThumbnailGenerator::new(png_renderer);
             let _ = generator
-                .create_thumbnail_from_stream(&mut font_stream)
+                .create_thumbnail_from_stream(
+                    &mut font_stream,
+                    Some(&FontMimeTypes::OTF),
+                )
                 .unwrap();
         });
     });

--- a/c2pa-font-handler/src/lib.rs
+++ b/c2pa-font-handler/src/lib.rs
@@ -55,6 +55,7 @@ pub mod compression;
 pub mod data;
 pub mod error;
 pub(crate) mod magic;
+pub mod mime_type;
 pub mod sfnt;
 pub mod tag;
 #[cfg(feature = "thumbnails")]

--- a/c2pa-font-handler/src/mime_type.rs
+++ b/c2pa-font-handler/src/mime_type.rs
@@ -1,0 +1,136 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Help with MIME types for font files.
+
+use std::{
+    fmt::Display,
+    io::{Read, Seek},
+};
+
+use byteorder::{BigEndian, ReadBytesExt};
+
+use crate::magic::Magic;
+
+/// A very slim representation of MIME types for font files.
+#[derive(Debug, PartialEq, Eq)]
+pub enum FontMimeTypes {
+    /// OpenType font MIME type.
+    OTF,
+    /// TrueType font MIME type.
+    TTF,
+    /// WOFF font MIME type.
+    WOFF,
+    /// WOFF2 font MIME type.
+    WOFF2,
+}
+
+impl Display for FontMimeTypes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FontMimeTypes::OTF => write!(f, "font/otf"),
+            FontMimeTypes::TTF => write!(f, "font/ttf"),
+            FontMimeTypes::WOFF => write!(f, "font/woff"),
+            FontMimeTypes::WOFF2 => write!(f, "font/woff2"),
+        }
+    }
+}
+
+/// Various known magic types with their MIME types.
+pub struct MagicTypes {
+    /// The magic number for the font file format.
+    magic: Magic,
+    /// The MIME type associated with the magic number.
+    mime_type: FontMimeTypes,
+}
+
+impl MagicTypes {
+    /// Known MIME types for font files.
+    pub const KNOWN_TYPES: &'static [MagicTypes] =
+        &[Self::OTF, Self::TTF, Self::TTF_OTF, Self::WOFF, Self::WOFF2];
+    /// OpenType font magic number and MIME type.
+    pub const OTF: MagicTypes = MagicTypes {
+        magic: Magic::OpenType,
+        mime_type: FontMimeTypes::OTF,
+    };
+    /// TrueType MIME type.
+    pub const TTF: MagicTypes = MagicTypes {
+        magic: Magic::TrueType,
+        mime_type: FontMimeTypes::TTF,
+    };
+    /// Apple True OpenType font magic number and MIME type.
+    pub const TTF_OTF: MagicTypes = MagicTypes {
+        magic: Magic::AppleTrue,
+        mime_type: FontMimeTypes::OTF,
+    };
+    /// WOFF font magic number and MIME type.
+    pub const WOFF: MagicTypes = MagicTypes {
+        magic: Magic::Woff,
+        mime_type: FontMimeTypes::WOFF,
+    };
+    /// WOFF2 font magic number and MIME type.
+    pub const WOFF2: MagicTypes = MagicTypes {
+        magic: Magic::Woff2,
+        mime_type: FontMimeTypes::WOFF2,
+    };
+}
+
+/// Error type for MIME type guessing.
+#[derive(Debug, thiserror::Error)]
+pub enum MimeTypeError {
+    /// An error while reading/writing font data.
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    /// Error when the magic number does not match any known type.
+    #[error("Unknown font file format")]
+    UnknownMagicType,
+}
+
+/// A way to guess the MIME type from an object.
+pub trait FontMimeTypeGuesser {
+    /// The error type for the MIME type guessing.
+    type Error;
+
+    /// Guess the MIME type of the file based on its contents.
+    fn guess_mime_type(
+        &mut self,
+    ) -> Result<&'static FontMimeTypes, Self::Error>;
+}
+
+impl<T: Read + Seek + ?Sized> FontMimeTypeGuesser for T {
+    type Error = MimeTypeError;
+
+    fn guess_mime_type(
+        &mut self,
+    ) -> Result<&'static FontMimeTypes, Self::Error> {
+        // Grab the current position so we can rewind later
+        let current_position = self.stream_position()?;
+        // Read the first few bytes to determine the MIME type
+        let mut reader = self.take(4);
+        let magic = reader.read_u32::<BigEndian>()?;
+
+        // Rewind the reader to the original position
+        self.seek(std::io::SeekFrom::Start(current_position))?;
+
+        MagicTypes::KNOWN_TYPES
+            .iter()
+            .find(|&magic_type| magic == magic_type.magic as u32)
+            .map(|magic_type| &magic_type.mime_type)
+            .ok_or(MimeTypeError::UnknownMagicType)
+    }
+}
+
+#[cfg(test)]
+#[path = "mime_type_test.rs"]
+mod tests;

--- a/c2pa-font-handler/src/mime_type_test.rs
+++ b/c2pa-font-handler/src/mime_type_test.rs
@@ -1,0 +1,68 @@
+// Copyright 2025 Monotype Imaging Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Tests for MIME type handling in C2PA font handler.
+
+use super::*;
+
+#[test]
+fn test_guess_mime_type_otf() {
+    let mut reader = std::io::Cursor::new(&b"OTTO"[..]);
+    let mime_type = reader.guess_mime_type().unwrap();
+    assert_eq!(mime_type, &FontMimeTypes::OTF);
+
+    let mut reader = std::io::Cursor::new(&b"true"[..]);
+    let mime_type = reader.guess_mime_type().unwrap();
+    assert_eq!(mime_type, &FontMimeTypes::OTF);
+}
+
+#[test]
+fn test_guess_mime_type_ttf() {
+    let mut reader = std::io::Cursor::new(&b"\x00\x01\x00\x00"[..]);
+    let mime_type = reader.guess_mime_type().unwrap();
+    assert_eq!(mime_type, &FontMimeTypes::TTF);
+}
+
+#[test]
+fn test_guess_mime_type_woff() {
+    let mut reader = std::io::Cursor::new(&b"\x77\x4F\x46\x46"[..]);
+    let mime_type = reader.guess_mime_type().unwrap();
+    assert_eq!(mime_type, &FontMimeTypes::WOFF);
+}
+
+#[test]
+fn test_guess_mime_type_woff2() {
+    let mut reader = std::io::Cursor::new(&b"\x77\x4F\x46\x32"[..]);
+    let mime_type = reader.guess_mime_type().unwrap();
+    assert_eq!(mime_type, &FontMimeTypes::WOFF2);
+}
+
+#[test]
+fn test_guess_mime_type_unknown() {
+    let mut reader = std::io::Cursor::new(&b"unknown"[..]);
+    let result = reader.guess_mime_type();
+    assert!(result.is_err());
+    assert!(matches!(
+        result.err().unwrap(),
+        MimeTypeError::UnknownMagicType
+    ));
+}
+
+#[test]
+fn test_font_mime_types_display() {
+    assert_eq!(FontMimeTypes::OTF.to_string(), "font/otf");
+    assert_eq!(FontMimeTypes::TTF.to_string(), "font/ttf");
+    assert_eq!(FontMimeTypes::WOFF.to_string(), "font/woff");
+    assert_eq!(FontMimeTypes::WOFF2.to_string(), "font/woff2");
+}

--- a/c2pa-font-handler/src/thumbnail.rs
+++ b/c2pa-font-handler/src/thumbnail.rs
@@ -34,6 +34,8 @@ pub(crate) mod text;
 use text::TextFontSystemContext;
 pub use text::{CosmicTextThumbnailGenerator, FontSystemConfig};
 
+use crate::mime_type::{FontMimeTypeGuesser, FontMimeTypes};
+
 /// Represents a thumbnail.
 #[derive(Debug)]
 pub struct Thumbnail {
@@ -104,7 +106,8 @@ pub trait ThumbnailGenerator {
     ) -> Result<Thumbnail, error::FontThumbnailError> {
         let mut reader =
             File::open(path).map_err(error::FontThumbnailError::IoError)?;
-        self.create_thumbnail_from_stream(&mut reader)
+        let mime_type = FontMimeTypeGuesser::guess_mime_type(&mut reader)?;
+        self.create_thumbnail_from_stream(&mut reader, Some(mime_type))
     }
 
     /// Create a thumbnail from a stream.
@@ -115,11 +118,15 @@ pub trait ThumbnailGenerator {
     /// # Parameters
     /// - `reader`: A mutable reference to a reader that implements `Read` and
     ///   `Seek`.
+    /// - `mime_type`: An optional MIME type of the data represented by the
+    ///   reader. If not provided, the MIME type will be guessed based on the
+    ///   contents of the reader when needed.
     ///
     /// # Errors
     /// Returns an error if the thumbnail could not be created from the stream.
     fn create_thumbnail_from_stream(
         &self,
         reader: &mut dyn ReadSeek,
+        mime_type: Option<&FontMimeTypes>,
     ) -> Result<Thumbnail, error::FontThumbnailError>;
 }

--- a/c2pa-font-handler/src/thumbnail/error.rs
+++ b/c2pa-font-handler/src/thumbnail/error.rs
@@ -18,6 +18,9 @@
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum FontThumbnailError {
+    /// Font I/O error while reading the font for thumbnail generation
+    #[error("Error reading font data for thumbnail generation; {0}")]
+    FontIoError(#[from] crate::error::FontIoError),
     /// Error from the image crate
     #[cfg(feature = "png-thumbnails")]
     #[error(transparent)]
@@ -25,6 +28,9 @@ pub enum FontThumbnailError {
     /// error from IO operations
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+    /// Error when guessing the MIME type of the font
+    #[error(transparent)]
+    MimeTypeError(#[from] crate::mime_type::MimeTypeError),
     /// A font was not found
     #[error("No font found")]
     NoFontFound,
@@ -55,4 +61,7 @@ pub enum FontThumbnailError {
     /// The SVG feature is not enabled
     #[error("The SVG feature is not enabled")]
     SvgFeatureNotEnabled,
+    /// The input is not a valid/supported font type
+    #[error("The MIME type of the input is not supported")]
+    UnsupportedInputMimeType,
 }

--- a/c2pa-font-handler/src/thumbnail/text_test.rs
+++ b/c2pa-font-handler/src/thumbnail/text_test.rs
@@ -21,10 +21,13 @@ use cosmic_text::{fontdb::Database, Buffer, Fallback, FontSystem, Metrics};
 use super::{
     create_font_system, measure_text, measure_text_in_buffer, NoFallback,
 };
-use crate::thumbnail::{
-    error::FontThumbnailError,
-    text::{load_font_data, FontNameInfo, FontSystemConfig, LoadedFont},
-    CosmicTextThumbnailGenerator, ThumbnailGenerator,
+use crate::{
+    mime_type::FontMimeTypes,
+    thumbnail::{
+        error::FontThumbnailError,
+        text::{load_font_data, FontNameInfo, FontSystemConfig, LoadedFont},
+        CosmicTextThumbnailGenerator, ThumbnailGenerator,
+    },
 };
 
 // Test converting a Arc<Font> to a FontNameInfo
@@ -218,6 +221,7 @@ fn test_measure_text_in_buffer() {
 }
 
 #[test]
+#[tracing_test::traced_test]
 fn test_new_cosmic_text_thumbnail_generator() {
     let mut renderer = crate::thumbnail::MockRenderer::new();
     renderer.expect_render_thumbnail().returning(|_| {
@@ -230,7 +234,7 @@ fn test_new_cosmic_text_thumbnail_generator() {
     let generator = CosmicTextThumbnailGenerator::new(renderer);
     let mut font_data =
         Cursor::new(include_bytes!("../../../.devtools/font.otf"));
-    let result = generator.create_thumbnail_from_stream(&mut font_data);
+    let result = generator.create_thumbnail_from_stream(&mut font_data, None);
     assert!(result.is_ok(), "Expected successful thumbnail creation");
     let thumbnail = result.unwrap();
     assert_eq!(
@@ -245,6 +249,101 @@ fn test_new_cosmic_text_thumbnail_generator() {
     assert!(
         thumbnail.data().starts_with(b"<svg"),
         "Expected thumbnail data to start with '<svg'"
+    );
+    assert!(
+        logs_contain("Guessing MIME type for font data",),
+        "Expected log message about guessing MIME type"
+    );
+    assert!(logs_contain(
+        "Attempting to generate thumbnail for source data with MIME type: font/otf"
+    ), "Expected log message about generating thumbnail for font/otf");
+    assert!(
+        logs_contain("Creating font system from SFNT data"),
+        "Expected log message about creating font system from SFNT data"
+    );
+    assert!(
+        logs_contain("Rendering thumbnail for SFNT font"),
+        "Expected log message about rendering thumbnail for SFNT font"
+    );
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn test_new_cosmic_text_thumbnail_generator_with_unsupported_mime_type() {
+    let mut renderer = crate::thumbnail::MockRenderer::new();
+    renderer.expect_render_thumbnail().returning(|_| {
+        Ok(crate::thumbnail::Thumbnail::new(
+            b"<svg></svg>".to_vec(),
+            "image/svg+xml".to_string(),
+        ))
+    });
+    let renderer = Box::new(renderer);
+    let generator = CosmicTextThumbnailGenerator::new(renderer);
+    let mut font_data =
+        Cursor::new(include_bytes!("../../../.devtools/font.otf"));
+    let result = generator.create_thumbnail_from_stream(
+        &mut font_data,
+        Some(&FontMimeTypes::WOFF2),
+    );
+    assert!(result.is_err(), "Expected error for unsupported mime type");
+    let error = result.unwrap_err();
+    assert!(
+        matches!(error, FontThumbnailError::UnsupportedInputMimeType),
+        "Expected error to be UnsupportedInputMimeType; found: {error:?}"
+    );
+    assert!(logs_contain(
+        "Attempting to generate thumbnail for source data with MIME type: font/woff2"
+    ), "Expected log message about unsupported MIME type");
+}
+
+#[cfg(feature = "woff")]
+#[test]
+#[tracing_test::traced_test]
+fn test_new_cosmic_text_thumbnail_generator_for_woff() {
+    let mut renderer = crate::thumbnail::MockRenderer::new();
+    renderer.expect_render_thumbnail().returning(|_| {
+        Ok(crate::thumbnail::Thumbnail::new(
+            b"<svg></svg>".to_vec(),
+            "image/svg+xml".to_string(),
+        ))
+    });
+    let renderer = Box::new(renderer);
+    let generator = CosmicTextThumbnailGenerator::new(renderer);
+    let mut font_data =
+        Cursor::new(include_bytes!("../../../.devtools/font.woff"));
+    let result = generator.create_thumbnail_from_stream(&mut font_data, None);
+    assert!(result.is_ok(), "Expected successful thumbnail creation");
+    let thumbnail = result.unwrap();
+    assert_eq!(
+        "image/svg+xml",
+        thumbnail.mime_type(),
+        "Expected mime type to be 'image/svg+xml'"
+    );
+    assert!(
+        !thumbnail.data().is_empty(),
+        "Expected thumbnail data to not be empty"
+    );
+    assert!(
+        thumbnail.data().starts_with(b"<svg"),
+        "Expected thumbnail data to start with '<svg'"
+    );
+    assert!(
+        logs_contain("Guessing MIME type for font data",),
+        "Expected log message about guessing MIME type"
+    );
+    assert!(logs_contain(
+        "Attempting to generate thumbnail for source data with MIME type: font/woff"
+    ), "Expected log message about generating thumbnail for font/woff");
+    assert!(
+        logs_contain("Converting WOFF/WOFF2 to SFNT"),
+        "Expected log message about converting WOFF/WOFF2 to SFNT"
+    );
+    assert!(logs_contain(
+        "Creating font system from SFNT data created from WOFF/WOFF2"
+    ), "Expected log message about creating font system from SFNT data created from WOFF/WOFF2");
+    assert!(
+        logs_contain("Rendering thumbnail for WOFF/WOFF2 font"),
+        "Expected log message about rendering thumbnail for WOFF/WOFF2 font"
     );
 }
 
@@ -265,7 +364,10 @@ fn test_cosmic_text_thumbnail_generator_with_font_system_config() {
     );
     let mut font_data =
         Cursor::new(include_bytes!("../../../.devtools/font.otf"));
-    let result = generator.create_thumbnail_from_stream(&mut font_data);
+    let result = generator.create_thumbnail_from_stream(
+        &mut font_data,
+        Some(&FontMimeTypes::OTF),
+    );
     // Check if the result is Ok
     assert!(result.is_ok());
     let thumbnail = result.unwrap();


### PR DESCRIPTION
<!--  Title should use the format: "ISSUE-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/ISSUE-123/featureName"  -->
<!--        Branch names for Bugs: "fix/ISSUE-123/bugFixName"       -->
# Issue(s)

- C2PA-691

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [X] **Merge Commit** will be updated with `(MAJOR)` | `(MINOR)` when appropriate
- [X] **PR labeled** appropriately
- [X] Changes include a single fix/feature
- [X] **Documentation** updated:
  - [X] Developer documentation (ReadMe files)
  - [X] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [X] **Test case(s)** added
  - [X] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

This release addresses a couple of things:

- Fixes when a file has a C2PA already in the file, but the data is not at the end of the file as the specification states
- Preview of thumbnail generation for WOFF1 files

# Verification Instructions
<!-- Instructions for checking or testing this change. -->